### PR TITLE
Add `inner_text` method to get text for current element only

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -171,6 +171,7 @@ element.name               # Get element name
 element.name = "new_name"  # Set element name
 element.text              # Get text content
 element.text = "content"   # Set text content
+element.inner_text        # Get text content for current node only
 element.inner_html        # Get inner XML content
 element.inner_html = xml   # Set inner XML content
 

--- a/lib/moxml/adapter/nokogiri.rb
+++ b/lib/moxml/adapter/nokogiri.rb
@@ -224,6 +224,11 @@ module Moxml
           node.content
         end
 
+        def inner_text(node)
+          text_children = node.children - node.element_children
+          text_children.map(&:content).join
+        end
+
         def set_text_content(node, content)
           node.native_content = content
         end

--- a/lib/moxml/adapter/oga.rb
+++ b/lib/moxml/adapter/oga.rb
@@ -237,6 +237,15 @@ module Moxml
           node.text
         end
 
+        def inner_text(node)
+          if node.respond_to?(:inner_text)
+            node.inner_text
+          else
+            # Oga::XML::Text node for example
+            node.text
+          end
+        end
+
         def set_text_content(node, content)
           if node.respond_to?(:inner_text)
             node.inner_text = content

--- a/lib/moxml/element.rb
+++ b/lib/moxml/element.rb
@@ -79,6 +79,10 @@ module Moxml
       adapter.set_text_content(@native, normalize_xml_value(content))
     end
 
+    def inner_text
+      adapter.inner_text(@native)
+    end
+
     def inner_html
       adapter.inner_html(@native)
     end

--- a/spec/support/shared_examples/element.rb
+++ b/spec/support/shared_examples/element.rb
@@ -106,5 +106,25 @@ RSpec.shared_examples "Moxml::Element" do
         expect(element.to_xml).to include("text<child></child>more")
       end
     end
+
+    describe "complex element structures" do
+      it "creates nested paragraphs without namespaces" do
+        outer_p = doc.create_element("p")
+        inner_p = doc.create_element("p")
+        inner_p.add_child("Some text inside paragraph")
+        outer_p.add_child(inner_p)
+
+        expect(outer_p.to_xml).to include("<p>Some text inside paragraph</p>")
+      end
+
+      it "does not return text of child elements in root text" do
+        outer_p = doc.create_element("p")
+        inner_p = doc.create_element("p")
+        inner_p.add_child("Some text inside paragraph")
+        outer_p.add_child(inner_p)
+        expect(outer_p.inner_text).to eq("")
+        expect(inner_p.text).to include("Some text inside paragraph")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds `inner_text` method in `Moxml::Element` for oga and nokogiri adapters.
The current `text` method returns the `text` for all children in the sub-tree so we need a method to get `text` for the current element only.

closes #12 