### PR TITLE
fix: allow user to globally set the default adapter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -456,9 +456,9 @@ end
 
 == Configuration
 
-Moxml can be configured globally or per instance:
+=== General
 
-NOTE: If you want to use an adapter other than `nokogiri` as the default, set it before processing any input using the syntax `Moxml::Config.default_adapter = <adapter-name>`.
+Moxml can be configured globally or per instance.
 
 [source,ruby]
 ----
@@ -475,6 +475,26 @@ moxml = Moxml.new do |config|
   config.strict = false
 end
 ----
+
+=== Default adapter selection
+
+To use an adapter other than `:nokogiri` as the global default, set it before
+processing any input using the following option.
+
+[source,ruby]
+----
+Moxml::Config.default_adapter = <adapter-symbol>
+----
+
+Moxml supports the following adapters:
+
+`:nokogiri`:: (default) https://github.com/sparklemotion/nokogiri[Nokogiri], a
+wrapper around the https://github.com/GNOME/libxml2[libxml2] C library
+
+`:oga`:: https://github.com/yorickpeterse/oga[Oga], a pure Ruby XML parser
+
+`:ox`:: https://github.com/ohler55/ox[Ox], a fast XML parser (not yet supported)
+
 
 == Thread safety
 
@@ -569,11 +589,11 @@ end
 
 == Contributing
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin feature/my-new-feature`)
-5. Create a new Pull Request
+. Fork the repository
+. Create your feature branch (`git checkout -b feature/my-new-feature`)
+. Commit your changes (`git commit -am 'Add some feature'`)
+. Push to the branch (`git push origin feature/my-new-feature`)
+. Create a new Pull Request
 
 == License
 

--- a/README.adoc
+++ b/README.adoc
@@ -458,6 +458,8 @@ end
 
 Moxml can be configured globally or per instance:
 
+NOTE: If you want to use an adapter other than `nokogiri` as the default, set it before processing any input using the syntax `Moxml::Config.default_adapter = <adapter-name>`.
+
 [source,ruby]
 ----
 # Global configuration

--- a/lib/moxml/config.rb
+++ b/lib/moxml/config.rb
@@ -6,8 +6,14 @@ module Moxml
     DEFAULT_ADAPTER = VALID_ADAPTERS.first
 
     class << self
+      attr_writer :default_adapter
+
       def default
-        @default ||= new(DEFAULT_ADAPTER, true, "UTF-8")
+        @default ||= new(default_adapter, true, "UTF-8")
+      end
+
+      def default_adapter
+        @default_adapter ||= DEFAULT_ADAPTER
       end
     end
 
@@ -38,7 +44,10 @@ module Moxml
       adapter
     end
 
-    alias default_adapter= adapter=
+    def default_adapter=(name)
+      self.adapter = name
+      self.class.default_adapter = name
+    end
 
     def adapter
       @adapter ||= Adapter.load(@adapter_name)

--- a/spec/moxml_spec.rb
+++ b/spec/moxml_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Moxml do
 
     it "uses configured options from the block" do
       Moxml.configure do |config|
-        config.adapter = :oga
+        config.default_adapter = :oga
         config.strict_parsing = false
         config.default_encoding = "US-ASCII"
       end


### PR DESCRIPTION
This PR updates the default adapter setting from **Nokogiri** to the optionally user-specified adapter.

related => **plurimath/plurimath#289**