### PR TITLE
Validate multiple roots

### DIFF
--- a/spec/support/shared_examples/document.rb
+++ b/spec/support/shared_examples/document.rb
@@ -106,5 +106,15 @@ RSpec.shared_examples "Moxml::Document" do
         "</root>"
       )
     end
+
+    it "prevents multiple roots", focus: true do
+      xml =
+        <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <root/><another_root/>
+        XML
+
+      expect { context.parse(xml) }.to raise_error(Moxml::Error)
+    end
   end
 end


### PR DESCRIPTION
Addresses #22 

We do have a validation to check if a document has multiple roots.
But maybe there is a way to bypass it