### PR TITLE
fix: Ox::Node monkey patch 

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -11,5 +11,13 @@ on:
 jobs:
   rake:
     uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      before-setup-ruby: |
+        mkdir -p .bundle
+        touch .bundle/config
+        cat .bundle/config
+        echo "---" >> .bundle/config
+        echo 'BUNDLE_BUILD__RUBY___LL: "--with-cflags=-std=gnu17"' >> .bundle/config
+        cat .bundle/config
     secrets:
       pat_token: ${{ secrets.LUTAML_CI_PAT_TOKEN }}

--- a/lib/moxml/adapter/customized_ox/attribute.rb
+++ b/lib/moxml/adapter/customized_ox/attribute.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../ox/node"
-
 module Moxml
   module Adapter
     module CustomizedOx

--- a/lib/moxml/adapter/customized_ox/namespace.rb
+++ b/lib/moxml/adapter/customized_ox/namespace.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../ox/node"
-
 module Moxml
   module Adapter
     module CustomizedOx

--- a/lib/moxml/adapter/customized_ox/text.rb
+++ b/lib/moxml/adapter/customized_ox/text.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../ox/node"
-
 module Moxml
   module Adapter
     module CustomizedOx

--- a/lib/moxml/adapter/ox.rb
+++ b/lib/moxml/adapter/ox.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require_relative "base"
-# before ox so that all Ox classes inherit the monkey-patched Node
-require_relative "../../ox/node"
 require "ox"
 require_relative "customized_ox/text"
 require_relative "customized_ox/attribute"
 require_relative "customized_ox/namespace"
 
+# insert :parent methods to all Ox classes inherit the Node class
+::Ox::Node.attr_accessor :parent
 module Moxml
   module Adapter
     class Ox < Base

--- a/lib/ox/node.rb
+++ b/lib/ox/node.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "ox/node"
-
-module Ox
-  class Node
-    attr_accessor :parent
-  end
-end


### PR DESCRIPTION
This is a quick fix for `Ox::Node` monkey patch causing an issue on Windows.

related to metanorma/metanorma-docker#216
related to plurimath/plurimath#381