### PR TITLE
fix: exclude comment nodes from inner_text in Nokogiri adapter

### DIFF
--- a/lib/moxml/adapter/nokogiri.rb
+++ b/lib/moxml/adapter/nokogiri.rb
@@ -288,7 +288,9 @@ module Moxml
         end
 
         def inner_text(node)
-          text_children = node.children - node.element_children
+          text_children = node.children.reject do |c|
+            c.element? || c.comment?
+          end
           text_children.map(&:content).join
         end
 

--- a/spec/integration/shared_examples/node_wrappers/element_behavior.rb
+++ b/spec/integration/shared_examples/node_wrappers/element_behavior.rb
@@ -129,6 +129,20 @@ RSpec.shared_examples "Moxml::Element" do
         expect(outer_p.inner_text).to eq("")
         expect(inner_p.text).to include("Some text inside paragraph")
       end
+
+      it "excludes comment content from inner_text" do
+        element.add_child(doc.create_comment("comment text"))
+        element.add_child("actual text")
+        expect(element.inner_text).to eq("actual text")
+      end
+
+      it "excludes comments mixed with text and elements from inner_text" do
+        element.add_child("before ")
+        element.add_child(doc.create_comment("a comment"))
+        element.add_child(doc.create_element("child"))
+        element.add_child("after")
+        expect(element.inner_text).to eq("before after")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Fix Nokogiri adapter `inner_text` to exclude comment node content
- `node.children - node.element_children` kept comments, but native Nokogiri excludes them
- This caused comment text to leak into `inner_text`, affecting downstream libraries

## Test plan
- [x] Moxml test suite passes
- [x] lutaml-model 3973 specs pass
- [x] sts-ruby 132 specs pass (previously failing TBX round-trip now passes)