### PR TITLE
Fix Oga serialization for Opal

### DIFF
--- a/lib/moxml/adapter/customized_oga/xml_generator.rb
+++ b/lib/moxml/adapter/customized_oga/xml_generator.rb
@@ -16,7 +16,7 @@ module Moxml
         def on_element(element, output)
           name = element.expanded_name
 
-          attrs = ""
+          attrs = []
           element.attributes.each do |attr|
             attrs << " "
             on_attribute(attr, attrs)
@@ -28,7 +28,7 @@ module Moxml
                           ">"
                         end
 
-          output << "<#{name}#{attrs}#{closing_tag}"
+          output << "<#{name}#{attrs.join}#{closing_tag}"
         end
 
         def on_namespace_definition(ns, output)

--- a/lib/moxml/adapter/oga.rb
+++ b/lib/moxml/adapter/oga.rb
@@ -479,7 +479,7 @@ module Moxml
 
             if should_include_decl && !node.xml_declaration && !has_existing_declaration
               # Need to add declaration - create default one
-              output = +""
+              output = []
               output << '<?xml version="1.0" encoding="UTF-8"?>'
               output << "\n"
 
@@ -491,10 +491,10 @@ module Moxml
                 output << ::Moxml::Adapter::CustomizedOga::XmlGenerator.new(child).to_xml
               end
 
-              return output
+              return output.join
             elsif !should_include_decl
               # Skip xml_declaration
-              output = +""
+              output = []
 
               # Serialize doctype if present
               output << node.doctype.to_xml << "\n" if node.doctype
@@ -506,7 +506,7 @@ module Moxml
                 output << ::Moxml::Adapter::CustomizedOga::XmlGenerator.new(child).to_xml
               end
 
-              return output
+              return output.join
             end
           end
 
@@ -514,19 +514,20 @@ module Moxml
           # But first check if we need to handle declaration specially
           if node.is_a?(::Oga::XML::Document) && node.xml_declaration
             # Document has declaration - use custom handling to avoid duplicates
-            output = +""
+            output = []
+            xml_declaration_serialized = false
 
             # Serialize children, but skip XmlDeclaration if it would cause duplication
             node.children.each do |child|
-              # Check if this would cause duplication by seeing if we already have one in output
-              if child.is_a?(::Oga::XML::XmlDeclaration) && output.include?("<?xml")
-                next # Skip duplicate declaration
-              end
+              xml_declaration = child.is_a?(::Oga::XML::XmlDeclaration)
+              next if xml_declaration && xml_declaration_serialized
+
+              xml_declaration_serialized = true if xml_declaration
 
               output << ::Moxml::Adapter::CustomizedOga::XmlGenerator.new(child).to_xml
             end
 
-            output
+            output.join
           else
             # Normal case - use XmlGenerator directly
             ::Moxml::Adapter::CustomizedOga::XmlGenerator.new(node).to_xml

--- a/spec/moxml/adapter/oga_spec.rb
+++ b/spec/moxml/adapter/oga_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe Moxml::Adapter::Oga do
 
   it_behaves_like "xml adapter"
 
+  describe "serialization" do
+    it "does not duplicate XML declarations when declaration nodes repeat" do
+      context = Moxml::Context.new(:oga)
+      doc = context.create_document
+
+      doc.add_child(doc.create_declaration("1.0", "UTF-8"))
+      doc.add_child(doc.create_declaration("1.0", "UTF-8"))
+      doc.add_child(doc.create_element("root"))
+
+      serialized = doc.to_xml
+
+      expect(serialized.scan("<?xml").size).to eq(1)
+      expect(serialized).to include("<root></root>")
+    end
+  end
+
   describe "entity handling" do
     it "preserves non-breaking space through parse and serialize round-trip" do
       xml = "<root>Item&nbsp;One</root>"


### PR DESCRIPTION
This PR replaces mutable string accumulators in Oga serialization with Opal-friendly array buffers.

It also keeps duplicate XML declaration handling intact and adds a regression spec for that case.
