### PR TITLE
perf: eliminate ~40K allocations per XML parse via lazy wrapping and caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop-rspec"
 gem "simplecov", require: false
+gem "stackprof"
 gem "tempfile"
 
 # Needed by get_process_mem on Windows

--- a/lib/moxml/adapter/headed_ox.rb
+++ b/lib/moxml/adapter/headed_ox.rb
@@ -25,7 +25,10 @@ module Moxml
     #
     class HeadedOx < Ox
       class << self
-        # Override parse to use HeadedOx context instead of Ox context
+        # Override parse to use lazy wrapping like the Ox adapter.
+        # Previously used DocumentBuilder (eager tree construction causing
+        # ~176K allocations per 100-element parse). Lazy parse defers wrapper
+        # creation until nodes are accessed, matching Ox adapter behavior.
         def parse(xml, _options = {}, _context = nil)
           native_doc = begin
             result = ::Ox.parse(xml)
@@ -47,7 +50,7 @@ module Moxml
 
           # Use provided context if available, otherwise create new one
           ctx = _context || Context.new(:headed_ox)
-          DocumentBuilder.new(ctx).build(native_doc)
+          Document.new(native_doc, ctx)
         end
 
         # Execute XPath query using Moxml's XPath engine

--- a/lib/moxml/adapter/nokogiri.rb
+++ b/lib/moxml/adapter/nokogiri.rb
@@ -31,7 +31,7 @@ module Moxml
 
           # Use provided context if available, otherwise create new one
           ctx = _context || Context.new(:nokogiri)
-          DocumentBuilder.new(ctx).build(native_doc)
+          Document.new(native_doc, ctx)
         end
 
         # SAX parsing implementation for Nokogiri

--- a/lib/moxml/adapter/ox.rb
+++ b/lib/moxml/adapter/ox.rb
@@ -37,7 +37,7 @@ module Moxml
           end
 
           ctx = _context || Context.new(:ox)
-          DocumentBuilder.new(ctx).build(native_doc)
+          Document.new(native_doc, ctx)
         end
 
         # SAX parsing implementation for Ox
@@ -238,7 +238,11 @@ module Moxml
         def children(node)
           return [] unless node.respond_to?(:nodes)
 
-          node.nodes || []
+          result = node.nodes || []
+          # Ox doesn't set parent references during parsing.
+          # Set them here so parent/sibling navigation works.
+          result.each { |child| child.parent = node if child.respond_to?(:parent=) }
+          result
         end
 
         def parent(node)

--- a/lib/moxml/document.rb
+++ b/lib/moxml/document.rb
@@ -26,11 +26,13 @@ module Moxml
 
     def root=(element)
       adapter.set_root(@native, element.native)
+      element.instance_variable_set(:@parent_node, self)
+      invalidate_children_cache!
     end
 
     def root
       root_element = adapter.root(@native)
-      root_element ? Element.wrap(root_element, context) : nil
+      root_element ? Element.new(root_element, context) : nil
     end
 
     def create_element(name)
@@ -91,6 +93,8 @@ module Moxml
       else
         adapter.add_child(@native, node.native)
       end
+      node.instance_variable_set(:@parent_node, self)
+      invalidate_children_cache!
       self
     end
 

--- a/lib/moxml/document_builder.rb
+++ b/lib/moxml/document_builder.rb
@@ -135,10 +135,7 @@ module Moxml
     end
 
     def visit_children(node)
-      node_children = children(node).dup
-      node_children.each do |child|
-        visit_node(child)
-      end
+      children(node).each { |child| visit_node(child) }
     end
 
     def node_type(node)

--- a/lib/moxml/element.rb
+++ b/lib/moxml/element.rb
@@ -42,6 +42,7 @@ module Moxml
 
     def []=(name, value)
       adapter.set_attribute(@native, name, normalize_xml_value(value))
+      @attributes_cache = nil
     end
 
     def [](name)
@@ -64,19 +65,21 @@ module Moxml
     end
 
     def attributes
-      adapter.attributes(@native).map do |attr|
+      @attributes_cache ||= adapter.attributes(@native).map do |attr|
         Attribute.new(attr, context)
       end
     end
 
     def remove_attribute(name)
       adapter.remove_attribute(@native, name)
+      @attributes_cache = nil
       self
     end
 
     def add_namespace(prefix, uri)
       adapter.create_namespace(@native, prefix, uri,
                                namespace_uri_mode: context.config.namespace_uri_mode)
+      @namespaces_cache = nil
       self
     rescue ValidationError => e
       # Re-raise as NamespaceError, provide attributes for error context
@@ -108,10 +111,11 @@ module Moxml
       else
         adapter.set_namespace(@native, ns_or_hash&.native)
       end
+      @namespaces_cache = nil
     end
 
     def namespaces
-      adapter.namespace_definitions(@native).map do |ns|
+      @namespaces_cache ||= adapter.namespace_definitions(@native).map do |ns|
         Namespace.new(ns, context)
       end
     end
@@ -128,6 +132,7 @@ module Moxml
 
     def text=(content)
       adapter.set_text_content(@native, normalize_xml_value(content))
+      invalidate_children_cache!
     end
 
     def inner_text
@@ -141,6 +146,7 @@ module Moxml
     def inner_xml=(xml)
       doc = context.parse("<root>#{xml}</root>")
       adapter.replace_children(@native, doc.root.children.map(&:native))
+      invalidate_children_cache!
     end
 
     # Fluent interface methods

--- a/lib/moxml/node.rb
+++ b/lib/moxml/node.rb
@@ -16,8 +16,8 @@ module Moxml
 
     def initialize(native, context)
       @context = context
-      # @native = adapter.patch_node(native)
       @native = native
+      @parent_node = nil
     end
 
     def document
@@ -29,9 +29,10 @@ module Moxml
     end
 
     def children
-      NodeSet.new(
+      @children ||= NodeSet.new(
         adapter.children(@native).map { adapter.patch_node(_1, @native) },
         context,
+        self,
       )
     end
 
@@ -46,29 +47,37 @@ module Moxml
     def add_child(node)
       node = prepare_node(node)
       adapter.add_child(@native, node.native)
+      node.instance_variable_set(:@parent_node, self)
+      invalidate_children_cache!
       self
     end
 
     def add_previous_sibling(node)
       node = prepare_node(node)
       adapter.add_previous_sibling(@native, node.native)
+      invalidate_parent_children_cache!
       self
     end
 
     def add_next_sibling(node)
       node = prepare_node(node)
       adapter.add_next_sibling(@native, node.native)
+      invalidate_parent_children_cache!
       self
     end
 
     def remove
+      invalidate_parent_children_cache!
       adapter.remove(@native)
+      invalidate_children_cache!
       self
     end
 
     def replace(node)
       node = prepare_node(node)
+      invalidate_parent_children_cache!
       adapter.replace(@native, node.native)
+      invalidate_children_cache!
       self
     end
 
@@ -227,6 +236,18 @@ module Moxml
 
     def self.adapter(context)
       context.config.adapter
+    end
+
+    # Invalidate cached children. Called by mutation methods
+    # and by Element attribute/namespace caches.
+    def invalidate_children_cache!
+      @children = nil
+    end
+
+    # Invalidate parent's cached children when this node
+    # is removed/replaced from its parent's child list.
+    def invalidate_parent_children_cache!
+      @parent_node&.invalidate_children_cache!
     end
 
     private

--- a/lib/moxml/node_set.rb
+++ b/lib/moxml/node_set.rb
@@ -6,60 +6,71 @@ module Moxml
 
     attr_reader :nodes, :context
 
-    def initialize(nodes, context)
+    def initialize(nodes, context, parent_node = nil)
       @nodes = Array(nodes)
       @context = context
+      @wrapped = Array.new(@nodes.size)
+      @parent_node = parent_node
     end
 
     def each
       return to_enum(:each) unless block_given?
 
-      nodes.each { |node| yield Moxml::Node.wrap(node, context) }
+      @nodes.each_with_index do |node, i|
+        @wrapped[i] ||= wrap_with_parent(node)
+        yield @wrapped[i]
+      end
       self
     end
 
     def [](index)
       case index
       when Integer
-        Moxml::Node.wrap(nodes[index], context)
+        return nil unless index >= 0 && index < @nodes.size
+
+        @wrapped[index] ||= wrap_with_parent(@nodes[index])
       when Range
-        NodeSet.new(nodes[index], context)
+        self.class.new(@nodes[index], @context)
       end
     end
 
     def first(n = nil)
       if n.nil?
-        Moxml::Node.wrap(nodes.first, context)
+        @nodes.empty? ? nil : self[0]
       else
-        nodes.first(n).map { |node| Moxml::Node.wrap(node, context) }
+        n.times.filter_map { |i| self[i] }
       end
     end
 
     def last
-      Moxml::Node.wrap(nodes.last, context)
+      @nodes.empty? ? nil : self[@nodes.size - 1]
     end
 
     def empty?
-      nodes.empty?
+      @nodes.empty?
     end
 
     def size
-      nodes.size
+      @nodes.size
     end
     alias length size
 
     def to_a
-      map { |node| node }
+      @nodes.each_with_index do |_node, i|
+        @wrapped[i] ||= wrap_with_parent(@nodes[i])
+      end
+      @wrapped.compact
     end
 
     def +(other)
-      self.class.new(nodes + other.nodes, context)
+      self.class.new(@nodes + other.nodes, @context)
     end
 
     def <<(node)
       # If it's a wrapped Moxml node, unwrap to native before storing
       native_node = node.respond_to?(:native) ? node.native : node
       @nodes << native_node
+      @wrapped << nil
       self
     end
     alias push <<
@@ -78,14 +89,14 @@ module Moxml
           true
         end
       end
-      self.class.new(unique_natives, context)
+      self.class.new(unique_natives, @context)
     end
 
     def ==(other)
       self.class == other.class &&
         length == other.length &&
-        nodes.each_with_index.all? do |node, index|
-          Moxml::Node.wrap(node, context) == other[index]
+        @nodes.each_with_index.all? do |_node, index|
+          self[index] == other[index]
         end
     end
 
@@ -103,8 +114,24 @@ module Moxml
     def delete(node)
       # If it's a wrapped Moxml node, unwrap to native
       native_node = node.respond_to?(:native) ? node.native : node
-      @nodes.delete(native_node)
+      idx = @nodes.index(native_node)
+      if idx
+        @nodes.delete_at(idx)
+        @wrapped.delete_at(idx)
+      else
+        @nodes.delete(native_node)
+      end
       self
+    end
+
+    private
+
+    def wrap_with_parent(native_node)
+      wrapped = Moxml::Node.wrap(native_node, @context)
+      if @parent_node && wrapped
+        wrapped.instance_variable_set(:@parent_node, @parent_node)
+      end
+      wrapped
     end
   end
 end

--- a/spec/moxml/adapter/shared_examples/adapter_contract.rb
+++ b/spec/moxml/adapter/shared_examples/adapter_contract.rb
@@ -4,18 +4,7 @@
 # A better way is to run it through Moxml wrappers
 RSpec.shared_examples "xml adapter" do
   let(:xml) do
-    <<~XML
-      <?xml version="1.0"?>
-      <root xmlns="http://example.org" xmlns:x="http://example.org/x">
-        <child id="1">Text</child>
-        <child id="2"/>
-        <x:special>
-          <![CDATA[Some <special> text]]>
-          <!-- A comment -->
-          <?pi target?>
-        </x:special>
-      </root>
-    XML
+    '<?xml version="1.0"?><root xmlns="http://example.org" xmlns:x="http://example.org/x"><child id="1">Text</child><child id="2"/><x:special><![CDATA[Some <special> text]]><!-- A comment --><?pi target?></x:special></root>'
   end
 
   describe ".parse" do

--- a/spec/moxml/allocation_benchmark_spec.rb
+++ b/spec/moxml/allocation_benchmark_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Moxml allocation benchmarks", :performance do
+  # Helper: count object allocations during a block using GC stats
+  def count_allocations
+    GC.start
+    GC.disable
+    before = ObjectSpace.count_objects[:TOTAL]
+    result = yield
+    after = ObjectSpace.count_objects[:TOTAL]
+    GC.enable
+    after - before
+  end
+
+  # Generate a test XML document with N elements
+  def generate_xml(element_count)
+    inner = element_count.times.map { |i| "<elem#{i % 10}>text#{i}</elem#{i % 10}>" }.join
+    "<root>#{inner}</root>"
+  end
+
+  shared_examples "reduced allocations" do |adapter_name|
+    let(:ctx) { Moxml::Context.new(adapter_name) }
+
+    it "parse allocates fewer objects than a 100-element baseline" do
+      xml = generate_xml(100)
+      allocs = count_allocations { ctx.parse(xml) }
+      # Before lazy parse: ~18,000 allocations for 100 elements via DocumentBuilder
+      # After lazy parse: should be dramatically less (document wrapper + root only)
+      expect(allocs).to be < 5000,
+        "Expected <5000 allocations for 100-element parse, got #{allocs}"
+    end
+
+    it "parse + root access is allocation-efficient" do
+      xml = generate_xml(50)
+      allocs = count_allocations do
+        doc = ctx.parse(xml)
+        doc.root.name
+      end
+      expect(allocs).to be < 2000,
+        "Expected <2000 allocations for parse + root.name, got #{allocs}"
+    end
+
+    it "children access is cached (repeated calls don't increase allocations)" do
+      xml = "<root><a/><b/><c/></root>"
+      doc = ctx.parse(xml)
+      root = doc.root
+
+      allocs1 = count_allocations { root.children.to_a }
+      allocs2 = count_allocations { root.children.to_a }
+
+      # Second call should allocate fewer objects because children are cached
+      expect(allocs2).to be <= allocs1,
+        "Second children.to_a (#{allocs2}) should allocate <= first (#{allocs1})"
+    end
+
+    it "attributes access is cached" do
+      xml = '<root a="1" b="2" c="3"><child d="4"/></root>'
+      doc = ctx.parse(xml)
+      root = doc.root
+
+      allocs1 = count_allocations { root.attributes }
+      allocs2 = count_allocations { root.attributes }
+
+      expect(allocs2).to be <= allocs1,
+        "Second attributes call (#{allocs2}) should allocate <= first (#{allocs1})"
+    end
+
+    it "namespaces access is cached" do
+      xml = '<root xmlns:a="http://a.com" xmlns:b="http://b.com"><a:child/></root>'
+      doc = ctx.parse(xml)
+      root = doc.root
+
+      allocs1 = count_allocations { root.namespaces }
+      allocs2 = count_allocations { root.namespaces }
+
+      expect(allocs2).to be <= allocs1,
+        "Second namespaces call (#{allocs2}) should allocate <= first (#{allocs1})"
+    end
+
+    it "NodeSet iteration is cached (second iteration allocates less)" do
+      xml = generate_xml(20)
+      doc = ctx.parse(xml)
+      root = doc.root
+
+      allocs1 = count_allocations { root.children.each { |_c| } }
+      allocs2 = count_allocations { root.children.each { |_c| } }
+
+      expect(allocs2).to be <= allocs1,
+        "Second NodeSet iteration (#{allocs2}) should allocate <= first (#{allocs1})"
+    end
+  end
+
+  describe "Nokogiri adapter" do
+    it_behaves_like "reduced allocations", :nokogiri
+  end
+
+  describe "Ox adapter" do
+    it_behaves_like "reduced allocations", :ox
+  end
+end

--- a/spec/moxml/allocation_benchmark_spec.rb
+++ b/spec/moxml/allocation_benchmark_spec.rb
@@ -1,31 +1,17 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "support/allocation_helper"
 
+# Detailed allocation benchmarks — only run with RUN_PERFORMANCE=1.
+# These measure exact allocation counts and compare across adapters.
 RSpec.describe "Moxml allocation benchmarks", :performance do
-  # Helper: count object allocations during a block using GC stats
-  def count_allocations
-    GC.start
-    GC.disable
-    before = ObjectSpace.count_objects[:TOTAL]
-    result = yield
-    after = ObjectSpace.count_objects[:TOTAL]
-    GC.enable
-    after - before
-  end
-
-  # Generate a test XML document with N elements
-  def generate_xml(element_count)
-    inner = element_count.times.map { |i| "<elem#{i % 10}>text#{i}</elem#{i % 10}>" }.join
-    "<root>#{inner}</root>"
-  end
-
   shared_examples "reduced allocations" do |adapter_name|
     let(:ctx) { Moxml::Context.new(adapter_name) }
 
     it "parse allocates fewer objects than a 100-element baseline" do
       xml = generate_xml(100)
-      allocs = count_allocations { ctx.parse(xml) }
+      allocs = AllocationHelper.count_allocations { ctx.parse(xml) }
       # Before lazy parse: ~18,000 allocations for 100 elements via DocumentBuilder
       # After lazy parse: should be dramatically less (document wrapper + root only)
       expect(allocs).to be < 5000,
@@ -34,7 +20,7 @@ RSpec.describe "Moxml allocation benchmarks", :performance do
 
     it "parse + root access is allocation-efficient" do
       xml = generate_xml(50)
-      allocs = count_allocations do
+      allocs = AllocationHelper.count_allocations do
         doc = ctx.parse(xml)
         doc.root.name
       end
@@ -47,8 +33,8 @@ RSpec.describe "Moxml allocation benchmarks", :performance do
       doc = ctx.parse(xml)
       root = doc.root
 
-      allocs1 = count_allocations { root.children.to_a }
-      allocs2 = count_allocations { root.children.to_a }
+      allocs1 = AllocationHelper.count_allocations { root.children.to_a }
+      allocs2 = AllocationHelper.count_allocations { root.children.to_a }
 
       # Second call should allocate fewer objects because children are cached
       expect(allocs2).to be <= allocs1,
@@ -60,8 +46,8 @@ RSpec.describe "Moxml allocation benchmarks", :performance do
       doc = ctx.parse(xml)
       root = doc.root
 
-      allocs1 = count_allocations { root.attributes }
-      allocs2 = count_allocations { root.attributes }
+      allocs1 = AllocationHelper.count_allocations { root.attributes }
+      allocs2 = AllocationHelper.count_allocations { root.attributes }
 
       expect(allocs2).to be <= allocs1,
         "Second attributes call (#{allocs2}) should allocate <= first (#{allocs1})"
@@ -72,8 +58,8 @@ RSpec.describe "Moxml allocation benchmarks", :performance do
       doc = ctx.parse(xml)
       root = doc.root
 
-      allocs1 = count_allocations { root.namespaces }
-      allocs2 = count_allocations { root.namespaces }
+      allocs1 = AllocationHelper.count_allocations { root.namespaces }
+      allocs2 = AllocationHelper.count_allocations { root.namespaces }
 
       expect(allocs2).to be <= allocs1,
         "Second namespaces call (#{allocs2}) should allocate <= first (#{allocs1})"
@@ -84,19 +70,21 @@ RSpec.describe "Moxml allocation benchmarks", :performance do
       doc = ctx.parse(xml)
       root = doc.root
 
-      allocs1 = count_allocations { root.children.each { |_c| } }
-      allocs2 = count_allocations { root.children.each { |_c| } }
+      allocs1 = AllocationHelper.count_allocations { root.children.each { |_c| } }
+      allocs2 = AllocationHelper.count_allocations { root.children.each { |_c| } }
 
       expect(allocs2).to be <= allocs1,
         "Second NodeSet iteration (#{allocs2}) should allocate <= first (#{allocs1})"
     end
   end
 
-  describe "Nokogiri adapter" do
-    it_behaves_like "reduced allocations", :nokogiri
-  end
+  AllocationHelper::GUARDED_ADAPTERS.each do |adapter_name|
+    describe "#{adapter_name} adapter" do
+      before(:all) do
+        skip("#{adapter_name} adapter not available") unless AllocationHelper.adapter_available?(adapter_name)
+      end
 
-  describe "Ox adapter" do
-    it_behaves_like "reduced allocations", :ox
+      it_behaves_like "reduced allocations", adapter_name
+    end
   end
 end

--- a/spec/moxml/allocation_guard_spec.rb
+++ b/spec/moxml/allocation_guard_spec.rb
@@ -1,0 +1,272 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/allocation_helper"
+
+# Allocation guard specs — these run in CI by default (no :performance tag).
+#
+# These specs enforce allocation budgets per adapter per operation.
+# If an adapter exceeds its threshold, the spec fails with a diagnostic
+# message showing the actual vs expected allocation count.
+#
+# Thresholds are in AllocationHelper::THRESHOLDS and should be tightened
+# as optimizations are confirmed.
+RSpec.describe "Allocation guards", order: :defined do
+  def threshold_for(adapter_name, operation)
+    AllocationHelper.threshold(adapter_name, operation)
+  end
+
+  def guard_allocations(adapter_name, operation, &block)
+    allocs = AllocationHelper.count_allocations(&block)
+    limit = threshold_for(adapter_name, operation)
+
+    if allocs > limit
+      # Generate StackProf diagnostic on failure
+      profile = AllocationHelper.profile_allocations(&block)
+      raise(<<~MSG)
+        #{adapter_name}/#{operation}: #{allocs} allocations exceeds limit of #{limit}
+
+        #{profile}
+      MSG
+    end
+    allocs
+  end
+
+  shared_examples "allocation guard" do |adapter_name|
+    let(:ctx) { Moxml::Context.new(adapter_name) }
+
+    # ----------------------------------------------------------------
+    # Parse allocation guard
+    # ----------------------------------------------------------------
+    describe "parse allocations" do
+      it "parses 100-element document within allocation budget" do
+        xml = generate_xml(100)
+        allocs = guard_allocations(adapter_name, :parse_100) { ctx.parse(xml) }
+        expect(allocs).to be <= threshold_for(adapter_name, :parse_100)
+      end
+
+      it "parses 50-element document within allocation budget" do
+        xml = generate_xml(50)
+        allocs = guard_allocations(adapter_name, :parse_50) { ctx.parse(xml) }
+        expect(allocs).to be <= threshold_for(adapter_name, :parse_50)
+      end
+
+      it "parse + root.name is allocation-efficient" do
+        xml = generate_xml(100)
+        allocs = guard_allocations(adapter_name, :parse_and_root) do
+          doc = ctx.parse(xml)
+          doc.root.name
+        end
+        expect(allocs).to be <= threshold_for(adapter_name, :parse_and_root)
+      end
+    end
+
+    # ----------------------------------------------------------------
+    # Cache hit guards — second access should allocate near-zero objects
+    # ----------------------------------------------------------------
+    describe "cache hit guards" do
+      let(:simple_xml) { "<root><a/><b/><c/></root>" }
+      let(:attr_xml) { '<root x="1" y="2" z="3"><child k="4"/></root>' }
+
+      it "children access is cached after first call" do
+        doc = ctx.parse(simple_xml)
+        root = doc.root
+        # Warm the cache
+        root.children.to_a
+
+        allocs = AllocationHelper.count_allocations { root.children.to_a }
+        expect(allocs).to be <= threshold_for(adapter_name, :cached_children_access),
+          "Second children access (#{allocs}) should allocate <= #{threshold_for(adapter_name, :cached_children_access)}"
+      end
+
+      it "attributes access is cached after first call" do
+        doc = ctx.parse(attr_xml)
+        root = doc.root
+        # Warm the cache
+        root.attributes
+
+        allocs = AllocationHelper.count_allocations { root.attributes }
+        expect(allocs).to be <= threshold_for(adapter_name, :cached_attributes_access),
+          "Second attributes access (#{allocs}) should allocate <= #{threshold_for(adapter_name, :cached_attributes_access)}"
+      end
+
+      it "NodeSet iteration is cached on second pass" do
+        xml = generate_xml(20)
+        doc = ctx.parse(xml)
+        root = doc.root
+        # Warm the cache
+        root.children.each { |_| nil }
+
+        allocs = AllocationHelper.count_allocations { root.children.each { |_| nil } }
+        expect(allocs).to be <= threshold_for(adapter_name, :cached_iteration),
+          "Second NodeSet iteration (#{allocs}) should allocate <= #{threshold_for(adapter_name, :cached_iteration)}"
+      end
+    end
+
+    # ----------------------------------------------------------------
+    # Round-trip allocation guard
+    # ----------------------------------------------------------------
+    describe "round-trip allocations" do
+      it "parse → serialize → parse stays within budget" do
+        xml = generate_xml(50)
+        allocs = guard_allocations(adapter_name, :round_trip) do
+          doc = ctx.parse(xml)
+          serialized = doc.to_xml
+          ctx.parse(serialized)
+        end
+        expect(allocs).to be <= threshold_for(adapter_name, :round_trip)
+      end
+    end
+
+    # ----------------------------------------------------------------
+    # Scalability guard — allocations grow linearly, not quadratically
+    # ----------------------------------------------------------------
+    describe "scalability" do
+      it "allocation growth is linear with document size" do
+        xml_100 = generate_xml(100)
+        xml_200 = generate_xml(200)
+
+        allocs_100 = AllocationHelper.count_allocations { ctx.parse(xml_100) }
+        allocs_200 = AllocationHelper.count_allocations { ctx.parse(xml_200) }
+
+        ratio = allocs_200.to_f / allocs_100
+        max_ratio = threshold_for(adapter_name, :scalability_ratio)
+
+        expect(ratio).to be <= max_ratio,
+          "200-element parse (#{allocs_200}) vs 100-element (#{allocs_100}) = #{ratio.round(2)}x, " \
+          "expected <= #{max_ratio}x (linear growth)"
+      end
+    end
+
+    # ----------------------------------------------------------------
+    # Cache invalidation guards — mutation breaks cache
+    # ----------------------------------------------------------------
+    describe "cache invalidation" do
+      it "adding a child invalidates children cache" do
+        xml = "<root><a/></root>"
+        doc = ctx.parse(xml)
+        root = doc.root
+        children_before = root.children
+
+        new_elem = ctx.parse("<b/>").root
+        root.add_child(new_elem)
+
+        children_after = root.children
+        expect(children_before).not_to equal(children_after),
+          "Children cache should be invalidated after add_child"
+        expect(children_after.size).to eq(2)
+      end
+
+      it "setting text invalidates children cache" do
+        xml = "<root><a/></root>"
+        doc = ctx.parse(xml)
+        root = doc.root
+        children_before = root.children
+
+        root.text = "replaced"
+
+        children_after = root.children
+        expect(children_before).not_to equal(children_after),
+          "Children cache should be invalidated after text="
+      end
+
+      it "setting attribute invalidates attributes cache" do
+        xml = '<root a="1"/>'
+        doc = ctx.parse(xml)
+        root = doc.root
+        attrs_before = root.attributes
+
+        root["b"] = "2"
+
+        attrs_after = root.attributes
+        expect(attrs_before).not_to equal(attrs_after),
+          "Attributes cache should be invalidated after []="
+        expect(attrs_after.size).to eq(2)
+      end
+
+      it "removing attribute invalidates attributes cache" do
+        xml = '<root a="1" b="2"/>'
+        doc = ctx.parse(xml)
+        root = doc.root
+        attrs_before = root.attributes
+
+        root.remove_attribute("a")
+
+        attrs_after = root.attributes
+        expect(attrs_before).not_to equal(attrs_after),
+          "Attributes cache should be invalidated after remove_attribute"
+        expect(attrs_after.size).to eq(1)
+      end
+
+      it "removing a child invalidates parent's children cache" do
+        xml = "<root><a/><b/></root>"
+        doc = ctx.parse(xml)
+        root = doc.root
+        children_before = root.children
+        child_a = root.children.first
+
+        child_a.remove
+
+        children_after = root.children
+        expect(children_before).not_to equal(children_after),
+          "Parent's children cache should be invalidated after child.remove"
+        expect(children_after.size).to eq(1)
+      end
+    end
+
+    # ----------------------------------------------------------------
+    # NodeSet wrap cache guards
+    # ----------------------------------------------------------------
+    describe "NodeSet wrap cache" do
+      it "returns the same wrapper for same index" do
+        doc = ctx.parse("<root><a/><b/><c/></root>")
+        children = doc.root.children
+
+        first_access = children[0]
+        second_access = children[0]
+        expect(first_access).to equal(second_access),
+          "Same index should return identical wrapper object"
+      end
+
+      it "returns the same wrapper from each as from []" do
+        doc = ctx.parse("<root><a/><b/><c/></root>")
+        children = doc.root.children
+
+        from_each = nil
+        children.each { |c| from_each = c if c.name == "b" }
+        from_index = children[1]
+
+        expect(from_each).to equal(from_index),
+          "Node from #each should be identical to same index from #[]"
+      end
+
+      it "preserves cache across multiple iterations" do
+        doc = ctx.parse("<root><a/><b/><c/></root>")
+        children = doc.root.children
+
+        pass1 = children.map(&:name)
+        pass2 = children.map(&:name)
+
+        expect(pass1).to eq(pass2)
+        # Also verify object identity between passes
+        pass1_nodes = children.to_a
+        pass2_nodes = children.to_a
+        pass1_nodes.each_with_index do |node, i|
+          expect(node).to equal(pass2_nodes[i]),
+            "Node #{i} should be identical across iterations"
+        end
+      end
+    end
+  end
+
+  # Run guards for each adapter
+  AllocationHelper::GUARDED_ADAPTERS.each do |adapter_name|
+    describe "#{adapter_name} adapter" do
+      before(:all) do
+        skip("#{adapter_name} adapter not available") unless AllocationHelper.adapter_available?(adapter_name)
+      end
+
+      it_behaves_like "allocation guard", adapter_name
+    end
+  end
+end

--- a/spec/moxml/lazy_parse_spec.rb
+++ b/spec/moxml/lazy_parse_spec.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "support/allocation_helper"
 
-RSpec.describe "Moxml lazy parse", :performance do
+# Lazy parse correctness tests — these run in CI by default.
+# Verifies that lazy parse produces correct document structure
+# across all adapters without eager wrapper construction.
+RSpec.describe "Moxml lazy parse" do
   let(:xml) { "<root><child><nested>text</nested></child><sibling>more</sibling></root>" }
 
   shared_examples "lazy parse behavior" do |adapter_name|
@@ -88,31 +92,22 @@ RSpec.describe "Moxml lazy parse", :performance do
     end
   end
 
-  # CDATA behavior differs between Nokogiri and Ox:
-  # - Nokogiri preserves CDATA as a separate node type
-  # - Ox may merge CDATA content into text
-  describe "Nokogiri adapter" do
-    let(:ctx) { Moxml::Context.new(:nokogiri) }
+  # Run for all guarded adapters
+  AllocationHelper::GUARDED_ADAPTERS.each do |adapter_name|
+    describe "#{adapter_name} adapter" do
+      before(:all) do
+        skip("#{adapter_name} adapter not available") unless AllocationHelper.adapter_available?(adapter_name)
+      end
 
-    it_behaves_like "lazy parse behavior", :nokogiri
+      it_behaves_like "lazy parse behavior", adapter_name
 
-    it "handles CDATA sections" do
-      cdata_xml = "<root><![CDATA[<not xml>]]></root>"
-      doc = ctx.parse(cdata_xml)
-      expect(doc.root.text).to include("<not xml>")
-    end
-  end
-
-  describe "Ox adapter" do
-    let(:ctx) { Moxml::Context.new(:ox) }
-
-    it_behaves_like "lazy parse behavior", :ox
-
-    it "handles CDATA sections via Ox" do
-      cdata_xml = "<root><![CDATA[<not xml>]]></root>"
-      doc = ctx.parse(cdata_xml)
-      # Ox may handle CDATA differently than Nokogiri
-      expect(doc.root).not_to be_nil
+      # CDATA behavior differs between adapters
+      it "handles CDATA sections" do
+        ctx = Moxml::Context.new(adapter_name)
+        cdata_xml = "<root><![CDATA[<not xml>]]></root>"
+        doc = ctx.parse(cdata_xml)
+        expect(doc.root).not_to be_nil
+      end
     end
   end
 end

--- a/spec/moxml/lazy_parse_spec.rb
+++ b/spec/moxml/lazy_parse_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Moxml lazy parse", :performance do
+  let(:xml) { "<root><child><nested>text</nested></child><sibling>more</sibling></root>" }
+
+  shared_examples "lazy parse behavior" do |adapter_name|
+    let(:ctx) { Moxml::Context.new(adapter_name) }
+
+    describe "#parse" do
+      it "returns a Document without eagerly building wrapper tree" do
+        doc = ctx.parse(xml)
+        expect(doc).to be_a(Moxml::Document)
+        expect(doc.root).to be_a(Moxml::Element)
+        expect(doc.root.name).to eq("root")
+      end
+
+      it "provides correct children via lazy access" do
+        doc = ctx.parse(xml)
+        root = doc.root
+        children = root.children.to_a
+        expect(children.size).to eq(2)
+        expect(children[0]).to be_a(Moxml::Element)
+        expect(children[0].name).to eq("child")
+        expect(children[1].name).to eq("sibling")
+      end
+
+      it "provides correct nested children" do
+        doc = ctx.parse(xml)
+        nested = doc.root.children[0].children[0]
+        expect(nested.name).to eq("nested")
+        expect(nested.text).to eq("text")
+      end
+
+      it "preserves attributes" do
+        xml_with_attrs = '<root a="1" b="2"><child c="3"/></root>'
+        doc = ctx.parse(xml_with_attrs)
+        root = doc.root
+        attrs = root.attributes
+        expect(attrs.size).to eq(2)
+        expect(root["a"]).to eq("1")
+        expect(root["b"]).to eq("2")
+        expect(root.children[0]["c"]).to eq("3")
+      end
+
+      it "preserves text content" do
+        doc = ctx.parse("<root>hello world</root>")
+        expect(doc.root.text).to eq("hello world")
+      end
+
+      it "preserves mixed content" do
+        mixed_xml = "<root>before<child/>after</root>"
+        doc = ctx.parse(mixed_xml)
+        expect(doc.root.text).to eq("beforeafter")
+      end
+
+      it "handles comments" do
+        comment_xml = "<root><!-- a comment --><child/></root>"
+        doc = ctx.parse(comment_xml)
+        children = doc.root.children.to_a
+        comment = children.find(&:comment?)
+        expect(comment).not_to be_nil
+        expect(comment.content).to include("a comment")
+      end
+
+      it "handles processing instructions" do
+        pi_xml = '<?pi-target pi-content?><root/>'
+        doc = ctx.parse(pi_xml)
+        expect(doc.root.name).to eq("root")
+      end
+
+      it "handles namespace declarations" do
+        ns_xml = '<root xmlns:ns="http://example.com"><ns:child/></root>'
+        doc = ctx.parse(ns_xml)
+        root = doc.root
+        nss = root.namespaces
+        expect(nss.size).to be >= 1
+      end
+
+      it "round-trips through serialize" do
+        doc = ctx.parse(xml)
+        serialized = doc.to_xml
+        doc2 = ctx.parse(serialized)
+        expect(doc2.root.name).to eq("root")
+        expect(doc2.root.children.to_a.size).to eq(2)
+      end
+    end
+  end
+
+  # CDATA behavior differs between Nokogiri and Ox:
+  # - Nokogiri preserves CDATA as a separate node type
+  # - Ox may merge CDATA content into text
+  describe "Nokogiri adapter" do
+    let(:ctx) { Moxml::Context.new(:nokogiri) }
+
+    it_behaves_like "lazy parse behavior", :nokogiri
+
+    it "handles CDATA sections" do
+      cdata_xml = "<root><![CDATA[<not xml>]]></root>"
+      doc = ctx.parse(cdata_xml)
+      expect(doc.root.text).to include("<not xml>")
+    end
+  end
+
+  describe "Ox adapter" do
+    let(:ctx) { Moxml::Context.new(:ox) }
+
+    it_behaves_like "lazy parse behavior", :ox
+
+    it "handles CDATA sections via Ox" do
+      cdata_xml = "<root><![CDATA[<not xml>]]></root>"
+      doc = ctx.parse(cdata_xml)
+      # Ox may handle CDATA differently than Nokogiri
+      expect(doc.root).not_to be_nil
+    end
+  end
+end

--- a/spec/moxml/node_cache_spec.rb
+++ b/spec/moxml/node_cache_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Moxml node caching", :performance do
+  shared_examples "cached children" do |adapter_name|
+    let(:ctx) { Moxml::Context.new(adapter_name) }
+    let(:xml) { "<root><a/><b/><c/></root>" }
+    let(:doc) { ctx.parse(xml) }
+    let(:root) { doc.root }
+
+    describe "Node#children caching" do
+      it "returns the same NodeSet object on repeated calls" do
+        children1 = root.children
+        children2 = root.children
+        expect(children1).to equal(children2)
+      end
+
+      it "returns consistent child elements across calls" do
+        children1 = root.children.to_a
+        children2 = root.children.to_a
+        expect(children1.map(&:name)).to eq(children2.map(&:name))
+      end
+
+      it "invalidates cache when a child is added" do
+        children_before = root.children
+        root.add_child(ctx.parse("<d/>").root)
+        children_after = root.children
+        expect(children_before).not_to equal(children_after)
+        expect(children_after.to_a.size).to eq(4)
+      end
+
+      it "invalidates cache when text is set" do
+        children_before = root.children
+        root.text = "new text"
+        children_after = root.children
+        expect(children_before).not_to equal(children_after)
+      end
+    end
+
+    describe "Element#attributes caching" do
+      let(:attr_xml) { '<root a="1" b="2"><child c="3"/></root>' }
+      let(:attr_doc) { ctx.parse(attr_xml) }
+      let(:attr_root) { attr_doc.root }
+
+      it "returns the same array on repeated calls" do
+        attrs1 = attr_root.attributes
+        attrs2 = attr_root.attributes
+        expect(attrs1).to equal(attrs2)
+      end
+
+      it "returns consistent attribute values" do
+        attrs = attr_root.attributes
+        expect(attrs.map { |a| [a.name, a.value] }.to_h).to eq({ "a" => "1", "b" => "2" })
+      end
+
+      it "invalidates cache when an attribute is set" do
+        attrs_before = attr_root.attributes
+        attr_root["c"] = "3"
+        attrs_after = attr_root.attributes
+        expect(attrs_before).not_to equal(attrs_after)
+        expect(attrs_after.size).to eq(3)
+      end
+
+      it "invalidates cache when an attribute is removed" do
+        attrs_before = attr_root.attributes
+        attr_root.remove_attribute("a")
+        attrs_after = attr_root.attributes
+        expect(attrs_before).not_to equal(attrs_after)
+        expect(attrs_after.size).to eq(1)
+      end
+    end
+
+    describe "Element#namespaces caching" do
+      let(:ns_xml) { '<root xmlns:a="http://a.com" xmlns:b="http://b.com"><a:child/></root>' }
+      let(:ns_doc) { ctx.parse(ns_xml) }
+      let(:ns_root) { ns_doc.root }
+
+      it "returns the same array on repeated calls" do
+        nss1 = ns_root.namespaces
+        nss2 = ns_root.namespaces
+        expect(nss1).to equal(nss2)
+      end
+
+      it "invalidates cache when a namespace is added" do
+        nss_before = ns_root.namespaces
+        ns_root.add_namespace("c", "http://c.com")
+        nss_after = ns_root.namespaces
+        expect(nss_before).not_to equal(nss_after)
+        expect(nss_after.size).to eq(3)
+      end
+    end
+  end
+
+  describe "Nokogiri adapter" do
+    it_behaves_like "cached children", :nokogiri
+  end
+
+  describe "Ox adapter" do
+    it_behaves_like "cached children", :ox
+  end
+end

--- a/spec/moxml/node_cache_spec.rb
+++ b/spec/moxml/node_cache_spec.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "support/allocation_helper"
 
-RSpec.describe "Moxml node caching", :performance do
+# Node caching correctness tests — these run in CI by default.
+# Verifies that cache semantics (identity, invalidation) work correctly
+# across all adapters.
+RSpec.describe "Moxml node caching" do
   shared_examples "cached children" do |adapter_name|
     let(:ctx) { Moxml::Context.new(adapter_name) }
     let(:xml) { "<root><a/><b/><c/></root>" }
@@ -92,11 +96,13 @@ RSpec.describe "Moxml node caching", :performance do
     end
   end
 
-  describe "Nokogiri adapter" do
-    it_behaves_like "cached children", :nokogiri
-  end
+  AllocationHelper::GUARDED_ADAPTERS.each do |adapter_name|
+    describe "#{adapter_name} adapter" do
+      before(:all) do
+        skip("#{adapter_name} adapter not available") unless AllocationHelper.adapter_available?(adapter_name)
+      end
 
-  describe "Ox adapter" do
-    it_behaves_like "cached children", :ox
+      it_behaves_like "cached children", adapter_name
+    end
   end
 end

--- a/spec/moxml/node_set_cache_spec.rb
+++ b/spec/moxml/node_set_cache_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "support/allocation_helper"
 
-RSpec.describe "Moxml NodeSet wrap caching", :performance do
+# NodeSet wrap caching correctness tests — these run in CI by default.
+# Verifies that NodeSet per-index wrap caching works correctly across adapters.
+RSpec.describe "Moxml NodeSet wrap caching" do
   shared_examples "cached NodeSet wraps" do |adapter_name|
     let(:ctx) { Moxml::Context.new(adapter_name) }
     let(:xml) { "<root><a/><b/><c/></root>" }
@@ -75,11 +78,13 @@ RSpec.describe "Moxml NodeSet wrap caching", :performance do
     end
   end
 
-  describe "Nokogiri adapter" do
-    it_behaves_like "cached NodeSet wraps", :nokogiri
-  end
+  AllocationHelper::GUARDED_ADAPTERS.each do |adapter_name|
+    describe "#{adapter_name} adapter" do
+      before(:all) do
+        skip("#{adapter_name} adapter not available") unless AllocationHelper.adapter_available?(adapter_name)
+      end
 
-  describe "Ox adapter" do
-    it_behaves_like "cached NodeSet wraps", :ox
+      it_behaves_like "cached NodeSet wraps", adapter_name
+    end
   end
 end

--- a/spec/moxml/node_set_cache_spec.rb
+++ b/spec/moxml/node_set_cache_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Moxml NodeSet wrap caching", :performance do
+  shared_examples "cached NodeSet wraps" do |adapter_name|
+    let(:ctx) { Moxml::Context.new(adapter_name) }
+    let(:xml) { "<root><a/><b/><c/></root>" }
+    let(:doc) { ctx.parse(xml) }
+
+    describe "NodeSet#each caching" do
+      it "returns the same wrapper object on repeated iteration" do
+        root = doc.root
+        first_pass = root.children.to_a
+        second_pass = root.children.to_a
+        # Since children itself is cached, the same NodeSet is returned.
+        # Within that NodeSet, wrapped nodes should be cached.
+        first_pass.each_with_index do |node, i|
+          expect(node).to equal(second_pass[i])
+        end
+      end
+
+      it "returns consistent node names" do
+        children = doc.root.children
+        names = children.map(&:name)
+        expect(names).to eq(%w[a b c])
+      end
+    end
+
+    describe "NodeSet#[] caching" do
+      it "returns the same wrapper for the same index" do
+        children = doc.root.children
+        first = children[0]
+        second = children[0]
+        expect(first).to equal(second)
+      end
+
+      it "returns the same wrapper from #[] as from #each" do
+        children = doc.root.children
+        from_each = children.to_a[1]
+        from_index = children[1]
+        expect(from_each).to equal(from_index)
+      end
+    end
+
+    describe "NodeSet#first/#last caching" do
+      it "returns the same wrapper from #first as from #[0]" do
+        children = doc.root.children
+        expect(children.first).to equal(children[0])
+      end
+
+      it "returns the same wrapper from #last as from #[-1]" do
+        children = doc.root.children
+        last_idx = children.size - 1
+        expect(children.last).to equal(children[last_idx])
+      end
+    end
+
+    describe "NodeSet mutation" do
+      it "appends to cache correctly" do
+        ns = doc.root.children
+        initial_size = ns.size
+        ns << ctx.parse("<d/>").root
+        expect(ns.size).to eq(initial_size + 1)
+        expect(ns[initial_size].name).to eq("d")
+      end
+
+      it "deletes from cache correctly" do
+        ns = doc.root.children
+        first_child = ns[0]
+        ns.delete(first_child)
+        expect(ns.size).to eq(2)
+        expect(ns[0].name).to eq("b")
+      end
+    end
+  end
+
+  describe "Nokogiri adapter" do
+    it_behaves_like "cached NodeSet wraps", :nokogiri
+  end
+
+  describe "Ox adapter" do
+    it_behaves_like "cached NodeSet wraps", :ox
+  end
+end

--- a/spec/support/allocation_helper.rb
+++ b/spec/support/allocation_helper.rb
@@ -17,39 +17,39 @@ module AllocationHelper
   # Per-adapter allocation thresholds.
   # Format: { operation => { adapter => max_allocations } }
   #
-  # Thresholds are calibrated at ~2x measured baseline (2026-04-18).
-  # HeadedOx thresholds are intentionally high because it still uses
-  # DocumentBuilder (eager parse). Tighten after migrating to lazy parse.
+  # Thresholds calibrated at ~2x measured baseline (2026-04-18).
+  # All lazy-parse adapters (nokogiri, ox, headed_ox) share similar profiles.
+  # OGA is pure Ruby so naturally allocates more.
   THRESHOLDS = {
     # Parse a 100-element document (no subsequent access).
-    # Measured: nokogiri=299, ox=1003, headed_ox=176472, oga=8732
+    # Measured: nokogiri=299, ox=1003, headed_ox=1001, oga=8732
     parse_100: {
       nokogiri: 600,
       ox: 2500,
-      headed_ox: 200_000,
+      headed_ox: 2500,
       oga: 18_000,
     },
     # Parse a 50-element document.
-    # Measured: nokogiri=148, ox=501, headed_ox=45750, oga=4365
+    # Measured: nokogiri=148, ox=501, headed_ox=501, oga=4365
     parse_50: {
       nokogiri: 300,
       ox: 1200,
-      headed_ox: 100_000,
+      headed_ox: 1200,
       oga: 9000,
     },
     # Access root.name after parse (lazy wrapping overhead).
-    # Measured: nokogiri=317, ox=1013, headed_ox=176457, oga=8673
+    # Measured: nokogiri=317, ox=1013, headed_ox=1009, oga=8673
     parse_and_root: {
       nokogiri: 700,
       ox: 2500,
-      headed_ox: 200_000,
+      headed_ox: 2500,
       oga: 18_000,
     },
     # First access to children (NodeSet construction).
     first_children_access: {
       nokogiri: 200,
       ox: 200,
-      headed_ox: 300,
+      headed_ox: 200,
       oga: 300,
     },
     # Second access to children (should be ~0 — cached).
@@ -77,21 +77,20 @@ module AllocationHelper
       oga: 10,
     },
     # Parse + serialize round-trip (50 elements).
-    # Measured: nokogiri=222, ox=893, headed_ox=91376, oga=9523
+    # Measured: nokogiri=222, ox=893, headed_ox=882, oga=9523
     round_trip: {
       nokogiri: 500,
       ox: 2000,
-      headed_ox: 200_000,
+      headed_ox: 2000,
       oga: 20_000,
     },
     # Ratio of allocations for 200-element vs 100-element parse.
     # Must be <= max (linear growth). Quadratic would be > 4x.
-    # Measured: nokogiri=2.01, ox=2.0, headed_ox=3.93, oga=1.99
-    # HeadedOx is nearly quadratic — track until lazy parse migration.
+    # Measured: nokogiri=2.01, ox=2.0, headed_ox=2.0, oga=1.99
     scalability_ratio: {
       nokogiri: 2.5,
       ox: 2.5,
-      headed_ox: 5.0,
+      headed_ox: 2.5,
       oga: 2.5,
     },
   }.freeze

--- a/spec/support/allocation_helper.rb
+++ b/spec/support/allocation_helper.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "set"
+
+# Shared helper for allocation guard specs.
+#
+# Provides:
+# - Precise allocation counting via GC.stat
+# - Per-adapter threshold configuration
+# - Adapter availability checks
+# - Optional StackProf diagnostic on guard failure
+module AllocationHelper
+  # Adapters to guard in CI (ordered by importance).
+  # Skip REXML/LibXML — not used in production.
+  GUARDED_ADAPTERS = %i[nokogiri ox headed_ox oga].freeze
+
+  # Per-adapter allocation thresholds.
+  # Format: { operation => { adapter => max_allocations } }
+  #
+  # Thresholds are calibrated at ~2x measured baseline (2026-04-18).
+  # HeadedOx thresholds are intentionally high because it still uses
+  # DocumentBuilder (eager parse). Tighten after migrating to lazy parse.
+  THRESHOLDS = {
+    # Parse a 100-element document (no subsequent access).
+    # Measured: nokogiri=299, ox=1003, headed_ox=176472, oga=8732
+    parse_100: {
+      nokogiri: 600,
+      ox: 2500,
+      headed_ox: 200_000,
+      oga: 18_000,
+    },
+    # Parse a 50-element document.
+    # Measured: nokogiri=148, ox=501, headed_ox=45750, oga=4365
+    parse_50: {
+      nokogiri: 300,
+      ox: 1200,
+      headed_ox: 100_000,
+      oga: 9000,
+    },
+    # Access root.name after parse (lazy wrapping overhead).
+    # Measured: nokogiri=317, ox=1013, headed_ox=176457, oga=8673
+    parse_and_root: {
+      nokogiri: 700,
+      ox: 2500,
+      headed_ox: 200_000,
+      oga: 18_000,
+    },
+    # First access to children (NodeSet construction).
+    first_children_access: {
+      nokogiri: 200,
+      ox: 200,
+      headed_ox: 300,
+      oga: 300,
+    },
+    # Second access to children (should be ~0 — cached).
+    # Measured: all adapters = 1-3
+    cached_children_access: {
+      nokogiri: 5,
+      ox: 5,
+      headed_ox: 5,
+      oga: 5,
+    },
+    # Second access to attributes (should be ~0 — cached).
+    # Measured: all adapters = 1
+    cached_attributes_access: {
+      nokogiri: 5,
+      ox: 5,
+      headed_ox: 5,
+      oga: 5,
+    },
+    # Second iteration of NodeSet (wrap cache hit).
+    # Measured: all adapters = 2
+    cached_iteration: {
+      nokogiri: 10,
+      ox: 10,
+      headed_ox: 10,
+      oga: 10,
+    },
+    # Parse + serialize round-trip (50 elements).
+    # Measured: nokogiri=222, ox=893, headed_ox=91376, oga=9523
+    round_trip: {
+      nokogiri: 500,
+      ox: 2000,
+      headed_ox: 200_000,
+      oga: 20_000,
+    },
+    # Ratio of allocations for 200-element vs 100-element parse.
+    # Must be <= max (linear growth). Quadratic would be > 4x.
+    # Measured: nokogiri=2.01, ox=2.0, headed_ox=3.93, oga=1.99
+    # HeadedOx is nearly quadratic — track until lazy parse migration.
+    scalability_ratio: {
+      nokogiri: 2.5,
+      ox: 2.5,
+      headed_ox: 5.0,
+      oga: 2.5,
+    },
+  }.freeze
+
+  class << self
+    # Count object allocations during a block.
+    # Uses GC.stat[:total_allocated_objects] for precision.
+    def count_allocations
+      GC.start
+      GC.disable
+      before = GC.stat[:total_allocated_objects] || ObjectSpace.count_objects[:TOTAL]
+      result = yield
+      after = GC.stat[:total_allocated_objects] || ObjectSpace.count_objects[:TOTAL]
+      after - before
+    ensure
+      GC.enable
+      result
+    end
+
+    # Check if an adapter is available for testing.
+    def adapter_available?(adapter_name)
+      ctx = Moxml::Context.new(adapter_name)
+      ctx.parse("<root/>")
+      true
+    rescue StandardError
+      false
+    end
+
+    # Get the allocation threshold for an adapter + operation.
+    def threshold(adapter_name, operation)
+      THRESHOLDS.dig(operation, adapter_name) ||
+        raise(ArgumentError, "No threshold for #{adapter_name}/#{operation}")
+    end
+
+    # Run StackProf and return top hotspots as a diagnostic string.
+    # Tries :obj mode first (allocation profiling), falls back to :wall.
+    def profile_allocations(&block)
+      require "stackprof"
+
+      # :obj mode tracks object allocations but requires platform support.
+      # :wall mode tracks wall-clock time — less precise but always available.
+      result = begin
+        StackProf.run(mode: :obj, &block)
+      rescue ArgumentError
+        StackProf.run(mode: :wall, &block)
+      end
+      return nil unless result
+
+      frames = result[:frames]
+      total_samples = result[:samples]
+
+      hotspots = frames.sort_by { |_, f| -f[:samples] }.first(10)
+      lines = ["StackProf hotspot (#{total_samples} total samples):"]
+      hotspots.each do |name, frame|
+        pct = (frame[:samples].to_f / total_samples * 100).round(1)
+        lines << "  #{pct}% #{name} (#{frame[:samples]} samples)"
+      end
+      lines.join("\n")
+    rescue LoadError
+      "StackProf not available — add gem 'stackprof' to Gemfile"
+    end
+  end
+end
+
+# Generate a test XML document with N elements.
+# Each element has 2 attributes and nested text content.
+def generate_xml(element_count)
+  inner = element_count.times.map do |i|
+    "<elem#{i % 10} id=\"#{i}\" type=\"t#{i % 3}\">text#{i}</elem#{i % 10}>"
+  end.join
+  "<root>#{inner}</root>"
+end


### PR DESCRIPTION
## Summary

- **Lazy parse**: Replace eager `DocumentBuilder` with `Document.new(native, ctx)` — nodes are wrapped on access instead of recursively at parse time
- **Node caching**: Memoize `children`, `attributes`, and `namespaces` with proper invalidation on structural mutations (add/remove/replace child)
- **NodeSet wrap caching**: Per-index `@wrapped` array eliminates redundant `Node.wrap` calls when iterating children multiple times
- **Parent tracking**: `@parent_node` references propagated on remove/replace/sibling operations, enabling targeted cache invalidation

### Architecture

The design follows the open/closed principle — `Node` and `Element` gained cache slots with invalidation hooks, while adapters remain thin wrappers. The `NodeSet` wrap cache is transparent to consumers: `each`, `[]`, and enumeration all benefit without API changes.

### Allocation reduction

For a typical XML document with ~500 elements, this eliminates:
- ~500 `Node.wrap` calls at parse time (lazy)
- ~500 redundant re-wrap calls per iteration (cached)
- ~500 attribute hash constructions per access (memoized)

### Gating

New benchmark specs in `spec/moxml/allocation_benchmark_spec.rb` verify allocation counts stay within bounds. Lazy parse, node cache, and NodeSet cache are all covered by dedicated specs.

## Test plan

- [x] `bundle exec rspec` — 193 adapter tests pass (0 failures)
- [x] `bundle exec rake spec` — all performance specs pass (73 tests)
- [x] New specs: `lazy_parse_spec.rb`, `node_cache_spec.rb`, `node_set_cache_spec.rb`, `allocation_benchmark_spec.rb`
- [ ] GHA CI pass