### PR TITLE
feat: same-document node creation and in_scope_namespaces

### DIFF
--- a/lib/moxml/adapter/base.rb
+++ b/lib/moxml/adapter/base.rb
@@ -61,23 +61,23 @@ module Moxml
           )
         end
 
-        def create_element(name)
+        def create_element(name, owner_doc: nil)
           validate_element_name(name)
-          create_native_element(name)
+          create_native_element(name, owner_doc)
         end
 
-        def create_text(content)
+        def create_text(content, owner_doc: nil)
           # Ox freezes the content, so we need to dup it
-          create_native_text(normalize_xml_value(content).dup)
+          create_native_text(normalize_xml_value(content).dup, owner_doc)
         end
 
-        def create_cdata(content)
-          create_native_cdata(normalize_xml_value(content))
+        def create_cdata(content, owner_doc: nil)
+          create_native_cdata(normalize_xml_value(content), owner_doc)
         end
 
-        def create_comment(content)
+        def create_comment(content, owner_doc: nil)
           validate_comment_content(content)
-          create_native_comment(normalize_xml_value(content))
+          create_native_comment(normalize_xml_value(content), owner_doc)
         end
 
         def create_doctype(name, external_id, system_id)
@@ -146,7 +146,7 @@ module Moxml
 
         protected
 
-        def create_native_element(_name)
+        def create_native_element(_name, _owner_doc = nil)
           raise Moxml::NotImplementedError.new(
             "create_native_element not implemented",
             feature: "create_native_element",
@@ -154,7 +154,7 @@ module Moxml
           )
         end
 
-        def create_native_text(_content)
+        def create_native_text(_content, _owner_doc = nil)
           raise Moxml::NotImplementedError.new(
             "create_native_text not implemented",
             feature: "create_native_text",
@@ -162,7 +162,7 @@ module Moxml
           )
         end
 
-        def create_native_cdata(_content)
+        def create_native_cdata(_content, _owner_doc = nil)
           raise Moxml::NotImplementedError.new(
             "create_native_cdata not implemented",
             feature: "create_native_cdata",
@@ -170,7 +170,7 @@ module Moxml
           )
         end
 
-        def create_native_comment(_content)
+        def create_native_comment(_content, _owner_doc = nil)
           raise Moxml::NotImplementedError.new(
             "create_native_comment not implemented",
             feature: "create_native_comment",
@@ -214,6 +214,14 @@ module Moxml
           raise Moxml::NotImplementedError.new(
             "create_native_entity_reference not implemented",
             feature: "create_native_entity_reference",
+            adapter: name,
+          )
+        end
+
+        def in_scope_namespaces(_element)
+          raise Moxml::NotImplementedError.new(
+            "in_scope_namespaces not implemented",
+            feature: "in_scope_namespaces",
             adapter: name,
           )
         end

--- a/lib/moxml/adapter/libxml.rb
+++ b/lib/moxml/adapter/libxml.rb
@@ -126,21 +126,21 @@ module Moxml
           ::LibXML::XML::Document.new
         end
 
-        def create_native_element(name)
+        def create_native_element(name, _owner_doc = nil)
           ::LibXML::XML::Node.new(name.to_s)
         end
 
-        def create_native_text(content)
+        def create_native_text(content, _owner_doc = nil)
           native = ::LibXML::XML::Node.new_text(content.to_s)
           CustomizedLibxml::Text.new(native)
         end
 
-        def create_native_cdata(content)
+        def create_native_cdata(content, _owner_doc = nil)
           native = ::LibXML::XML::Node.new_cdata(content.to_s)
           CustomizedLibxml::Cdata.new(native)
         end
 
-        def create_native_comment(content)
+        def create_native_comment(content, _owner_doc = nil)
           native = ::LibXML::XML::Node.new_comment(content.to_s)
           CustomizedLibxml::Comment.new(native)
         end

--- a/lib/moxml/adapter/nokogiri.rb
+++ b/lib/moxml/adapter/nokogiri.rb
@@ -70,20 +70,20 @@ module Moxml
           )
         end
 
-        def create_native_element(name)
-          ::Nokogiri::XML::Element.new(name, create_document)
+        def create_native_element(name, owner_doc = nil)
+          ::Nokogiri::XML::Element.new(name, owner_doc || create_document)
         end
 
-        def create_native_text(content)
-          ::Nokogiri::XML::Text.new(content, create_document)
+        def create_native_text(content, owner_doc = nil)
+          ::Nokogiri::XML::Text.new(content, owner_doc || create_document)
         end
 
-        def create_native_cdata(content)
-          ::Nokogiri::XML::CDATA.new(create_document, content)
+        def create_native_cdata(content, owner_doc = nil)
+          ::Nokogiri::XML::CDATA.new(owner_doc || create_document, content)
         end
 
-        def create_native_comment(content)
-          ::Nokogiri::XML::Comment.new(create_document, content)
+        def create_native_comment(content, owner_doc = nil)
+          ::Nokogiri::XML::Comment.new(owner_doc || create_document, content)
         end
 
         def create_native_doctype(name, external_id, system_id)
@@ -332,6 +332,10 @@ module Moxml
 
         def namespace_definitions(node)
           node.namespace_definitions
+        end
+
+        def in_scope_namespaces(element)
+          element.namespace_scopes
         end
 
         # Doctype accessor methods

--- a/lib/moxml/adapter/oga.rb
+++ b/lib/moxml/adapter/oga.rb
@@ -64,19 +64,19 @@ module Moxml
           ::Oga::XML::Document.new
         end
 
-        def create_native_element(name)
+        def create_native_element(name, _owner_doc = nil)
           ::Oga::XML::Element.new(name: name)
         end
 
-        def create_native_text(content)
+        def create_native_text(content, _owner_doc = nil)
           ::Oga::XML::Text.new(text: encode_entity_markers(content))
         end
 
-        def create_native_cdata(content)
+        def create_native_cdata(content, _owner_doc = nil)
           ::Oga::XML::Cdata.new(text: content)
         end
 
-        def create_native_comment(content)
+        def create_native_comment(content, _owner_doc = nil)
           ::Oga::XML::Comment.new(text: content)
         end
 

--- a/lib/moxml/adapter/ox.rb
+++ b/lib/moxml/adapter/ox.rb
@@ -67,21 +67,21 @@ module Moxml
           ::Ox::Document.new(**attrs)
         end
 
-        def create_native_element(name)
+        def create_native_element(name, _owner_doc = nil)
           element = ::Ox::Element.new(name)
           element.instance_variable_set(:@attributes, {})
           element
         end
 
-        def create_native_text(content)
+        def create_native_text(content, _owner_doc = nil)
           content
         end
 
-        def create_native_cdata(content)
+        def create_native_cdata(content, _owner_doc = nil)
           ::Ox::CData.new(content)
         end
 
-        def create_native_comment(content)
+        def create_native_comment(content, _owner_doc = nil)
           ::Ox::Comment.new(content)
         end
 

--- a/lib/moxml/adapter/rexml.rb
+++ b/lib/moxml/adapter/rexml.rb
@@ -69,19 +69,19 @@ module Moxml
           ::REXML::Document.new
         end
 
-        def create_native_element(name)
+        def create_native_element(name, _owner_doc = nil)
           ::REXML::Element.new(name.to_s)
         end
 
-        def create_native_text(content)
+        def create_native_text(content, _owner_doc = nil)
           ::REXML::Text.new(content.to_s, true, nil)
         end
 
-        def create_native_cdata(content)
+        def create_native_cdata(content, _owner_doc = nil)
           ::REXML::CData.new(content.to_s)
         end
 
-        def create_native_comment(content)
+        def create_native_comment(content, _owner_doc = nil)
           ::REXML::Comment.new(content.to_s)
         end
 

--- a/lib/moxml/document.rb
+++ b/lib/moxml/document.rb
@@ -34,19 +34,19 @@ module Moxml
     end
 
     def create_element(name)
-      Element.new(adapter.create_element(name), context)
+      Element.new(adapter.create_element(name, owner_doc: @native), context)
     end
 
     def create_text(content)
-      Text.new(adapter.create_text(content), context)
+      Text.new(adapter.create_text(content, owner_doc: @native), context)
     end
 
     def create_cdata(content)
-      Cdata.new(adapter.create_cdata(content), context)
+      Cdata.new(adapter.create_cdata(content, owner_doc: @native), context)
     end
 
     def create_comment(content)
-      Comment.new(adapter.create_comment(content), context)
+      Comment.new(adapter.create_comment(content, owner_doc: @native), context)
     end
 
     def create_doctype(name, external_id, system_id)

--- a/lib/moxml/element.rb
+++ b/lib/moxml/element.rb
@@ -117,6 +117,14 @@ module Moxml
     end
     alias namespace_definitions namespaces
 
+    # Returns all namespaces in scope for this element,
+    # including those inherited from ancestor elements.
+    def in_scope_namespaces
+      adapter.in_scope_namespaces(@native).map do |ns|
+        Namespace.new(ns, context)
+      end
+    end
+
     # Returns the namespace URI of this element (alias for namespace_uri)
     def namespace_name
       namespace_uri


### PR DESCRIPTION
## Summary
- Pass `owner_doc` to `create_native_*` methods so Nokogiri creates nodes in the target document instead of a fresh `::Nokogiri::XML::Document.new`. This avoids silent failures when reparenting nodes across documents.
- Add `Element#in_scope_namespaces` to return all namespaces visible at an element including inherited from ancestors (wraps Nokogiri's `namespace_scopes`).
- Update all adapter (`Oga`, `Ox`, `REXML`, `LibXML`) `create_native_*` signatures to accept optional `_owner_doc` parameter.
- Add `in_scope_namespaces` NotImplementedError stub in base adapter; only Nokogiri implements it currently.

## Motivation
These features are needed to eliminate `.native` escape hatches in lutaml-model's XML builder, enabling full Moxml adoption across all adapters.

## Test plan
- [x] All 2389 existing tests pass (0 failures)
- [ ] Tests for same-document node creation behavior (to be added if needed)
- [ ] Tests for `in_scope_namespaces` (to be added if needed)