### PR TITLE
fix: allow dots in namespace prefix validation

### DIFF
--- a/lib/moxml/xml_utils.rb
+++ b/lib/moxml/xml_utils.rb
@@ -81,7 +81,7 @@ module Moxml
     end
 
     def validate_prefix(prefix)
-      return if prefix.match?(/\A[a-zA-Z_][\w-]*\z/)
+      return if prefix.match?(/\A[a-zA-Z_][\w.\-]*\z/)
 
       raise ValidationError, "Invalid namespace prefix: #{prefix}"
     end


### PR DESCRIPTION
## Summary
- XML NCName spec permits dots (`.`) as valid NameChars, but the `validate_prefix` regex `/\A[a-zA-Z_][\w-]*\z/` was too restrictive
- This caused `Moxml::ValidationError: Invalid namespace prefix: xmlns_1.0` when serializing XML with namespace prefixes containing dots
- Fixed regex to `/\A[a-zA-Z_][\w.\-]*\z/` to accept dots

## Test plan
- [ ] Existing tests pass
- [ ] Namespace prefixes with dots (e.g., `xmlns_1.0`) no longer raise validation errors