### PR TITLE
Detect default XML adapter by runtime and availability

### DIFF
--- a/lib/moxml/config.rb
+++ b/lib/moxml/config.rb
@@ -3,7 +3,8 @@
 module Moxml
   class Config
     VALID_ADAPTERS = %i[nokogiri oga rexml ox headed_ox libxml].freeze
-    DEFAULT_ADAPTER = VALID_ADAPTERS.first
+    DEFAULT_ADAPTER = :nokogiri
+    OPAL_DEFAULT_ADAPTER = :oga
 
     # Entity loading modes:
     # - :required - Must load entities, raise error if unavailable (default)
@@ -20,7 +21,21 @@ module Moxml
       end
 
       def default_adapter
-        @default_adapter ||= DEFAULT_ADAPTER
+        @default_adapter ||= runtime_default_adapter
+      end
+
+      def runtime_default_adapter
+        return OPAL_DEFAULT_ADAPTER if RUBY_ENGINE == "opal"
+
+        detect_loaded_adapter || DEFAULT_ADAPTER
+      end
+
+      def detect_loaded_adapter
+        return :nokogiri if Object.const_defined?(:Nokogiri)
+        return :ox if Object.const_defined?(:Ox)
+        return :oga if Object.const_defined?(:Oga)
+
+        nil
       end
     end
 

--- a/spec/moxml/moxml_spec.rb
+++ b/spec/moxml/moxml_spec.rb
@@ -2,6 +2,28 @@
 
 # spec/moxml_spec.rb
 RSpec.describe Moxml do
+  around do |example|
+    original_default = Moxml::Config.instance_variable_get(:@default)
+    original_default_adapter = Moxml::Config.instance_variable_get(:@default_adapter)
+
+    Moxml::Config.remove_instance_variable(:@default) if Moxml::Config.instance_variable_defined?(:@default)
+    Moxml::Config.remove_instance_variable(:@default_adapter) if Moxml::Config.instance_variable_defined?(:@default_adapter)
+
+    example.run
+  ensure
+    if original_default.nil?
+      Moxml::Config.remove_instance_variable(:@default) if Moxml::Config.instance_variable_defined?(:@default)
+    else
+      Moxml::Config.instance_variable_set(:@default, original_default)
+    end
+
+    if original_default_adapter.nil?
+      Moxml::Config.remove_instance_variable(:@default_adapter) if Moxml::Config.instance_variable_defined?(:@default_adapter)
+    else
+      Moxml::Config.instance_variable_set(:@default_adapter, original_default_adapter)
+    end
+  end
+
   it "has a version number" do
     expect(Moxml::VERSION).not_to be_nil
   end
@@ -32,6 +54,23 @@ RSpec.describe Moxml do
 
       context = described_class.new
       expect(context.config.adapter_name).to eq(:nokogiri)
+    end
+
+    it "defaults to oga on Opal" do
+      stub_const("RUBY_ENGINE", "opal")
+
+      context = described_class.new
+      expect(context.config.adapter_name).to eq(:oga)
+    end
+
+    it "prefers ox when it is already loaded" do
+      allow(Object).to receive(:const_defined?).and_call_original
+      allow(Object).to receive(:const_defined?).with(:Nokogiri).and_return(false)
+      allow(Object).to receive(:const_defined?).with(:Ox).and_return(true)
+      allow(Object).to receive(:const_defined?).with(:Oga).and_return(false)
+
+      context = described_class.new
+      expect(context.config.adapter_name).to eq(:ox)
     end
 
     it "uses configured options from the block" do


### PR DESCRIPTION
This change is needed because `moxml` currently defaults to `:nokogiri`, which breaks Opal that rely on `:oga` as the XML backend.

In downstream usage, this shows up as:

`AdapterError: Failed to load nokogiri adapter`

The failure happens because Opal reaches the default adapter path before downstream libraries can override it, and Nokogiri is not the practical adapter for that runtime.

This PR updates default adapter selection so that:
- Opal uses `:oga`
- non-Opal runtimes still prefer already-available adapters before falling back to `:nokogiri`

That keeps existing MRI-style behavior flexible while fixing the Opal boot path.
