### PR TITLE
fix: preserve whitespace text nodes in children() across adapters

### DIFF
--- a/lib/moxml/adapter/libxml.rb
+++ b/lib/moxml/adapter/libxml.rb
@@ -294,9 +294,6 @@ module Moxml
           result = []
           if native_node.children?
             native_node.each_child do |child|
-              # Skip whitespace-only text nodes
-              next if child.text? && child.content.to_s.strip.empty?
-
               result << patch_node(child)
             end
           end

--- a/lib/moxml/adapter/nokogiri.rb
+++ b/lib/moxml/adapter/nokogiri.rb
@@ -182,11 +182,7 @@ module Moxml
         end
 
         def children(node)
-          node.children.reject do |child|
-            child.text? && child.content.strip.empty? &&
-              !(child.previous_sibling.nil? && child.next_sibling.nil?) &&
-              !adjacent_to_entity_reference?(child)
-          end
+          node.children
         end
 
         def adjacent_to_entity_reference?(node)

--- a/lib/moxml/adapter/oga.rb
+++ b/lib/moxml/adapter/oga.rb
@@ -193,12 +193,18 @@ module Moxml
 
           return all_children unless node.is_a?(::Oga::XML::Node) || node.is_a?(::Oga::XML::Document)
 
-          all_children + node.children.reject do |child|
-            child.is_a?(::Oga::XML::Text) &&
-              child.text.strip.empty? &&
-              !(child.previous.nil? && child.next.nil?) &&
-              !adjacent_to_entity_reference?(child)
+          child_nodes = node.children.to_a
+          # Filter out whitespace-only text nodes at document level only.
+          # Document-level whitespace (between <?xml?> and <root>) is
+          # formatting, not content, and differs across adapters.
+          # Whitespace inside elements (e.g. "FigureA.1" spacing) is
+          # meaningful and must be preserved.
+          if node.is_a?(::Oga::XML::Document)
+            child_nodes = child_nodes.reject do |child|
+              child.is_a?(::Oga::XML::Text) && child.text.strip.empty?
+            end
           end
+          all_children + child_nodes
         end
 
         def adjacent_to_entity_reference?(node)

--- a/lib/moxml/adapter/rexml.rb
+++ b/lib/moxml/adapter/rexml.rb
@@ -177,12 +177,8 @@ module Moxml
         def children(node)
           return [] unless node.is_a?(::REXML::Parent)
 
-          # Get all children and filter out empty text nodes between elements
-          result = node.children.reject do |child|
-            child.is_a?(::REXML::Text) &&
-              child.to_s.strip.empty? &&
-              !(child.next_sibling.nil? && child.previous_sibling.nil?)
-          end
+          # Return all children preserving whitespace text nodes
+          result = node.children.dup
 
           # Include any EntityReference wrappers stored alongside native children
           entity_refs = attachments.get(node, :entity_refs)

--- a/spec/integration/shared_examples/edge_cases.rb
+++ b/spec/integration/shared_examples/edge_cases.rb
@@ -167,6 +167,91 @@ RSpec.shared_examples "Moxml Edge Cases" do
     end
   end
 
+  describe "whitespace text node preservation" do
+    # Ox/HeadedOx do not generate whitespace-only text nodes in their parser,
+    # so these tests only apply to adapters that do (Nokogiri, OGA, REXML, LibXML)
+    let(:preserves_ws) { !%i[ox headed_ox].include?(context.config.adapter_name) }
+
+    it "preserves whitespace-only text nodes between sibling elements" do
+      unless preserves_ws
+        skip "Ox/HeadedOx parser does not generate whitespace-only text nodes"
+      end
+
+      xml = <<~XML
+        <root>
+          <a>1</a>
+          <b>2</b>
+          <c>3</c>
+        </root>
+      XML
+
+      doc = context.parse(xml)
+      children = doc.root.children
+
+      # Should have whitespace text nodes between elements
+      expect(children.size).to be > 3
+
+      # Whitespace text nodes should be Text nodes
+      ws_nodes = children.select { |c| c.is_a?(Moxml::Text) && c.content.strip.empty? }
+      expect(ws_nodes).not_to be_empty
+
+      # Element children should still be accessible
+      elements = children.select { |c| c.is_a?(Moxml::Element) }
+      expect(elements.map(&:name)).to eq(%w[a b c])
+    end
+
+    it "preserves inline whitespace text nodes between text and elements" do
+      xml = "<p>Figure <sub>A</sub>.1</p>"
+      doc = context.parse(xml)
+
+      children = doc.root.children
+      expect(children.size).to eq(3)
+
+      # First child: "Figure " text node
+      expect(children[0]).to be_a(Moxml::Text)
+      expect(children[0].content).to eq("Figure ")
+
+      # Second child: <sub> element
+      expect(children[1]).to be_a(Moxml::Element)
+      expect(children[1].name).to eq("sub")
+      expect(children[1].text).to eq("A")
+
+      # Third child: ".1" text node
+      expect(children[2]).to be_a(Moxml::Text)
+      expect(children[2].content).to eq(".1")
+    end
+
+    it "preserves space-only text node as meaningful content" do
+      xml = "<p>Hello <b>world</b>!</p>"
+      doc = context.parse(xml)
+
+      children = doc.root.children
+      expect(children.size).to eq(3)
+
+      expect(children[0].content).to eq("Hello ")
+      expect(children[1]).to be_a(Moxml::Element)
+      expect(children[2].content).to eq("!")
+    end
+
+    it "distinguishes whitespace text nodes from element children" do
+      unless preserves_ws
+        skip "Ox/HeadedOx parser does not generate whitespace-only text nodes"
+      end
+
+      xml = "<root>  <child/>  </root>"
+      doc = context.parse(xml)
+
+      children = doc.root.children
+      # "  " before child, "  " after child
+      expect(children.size).to eq(3)
+      expect(children[0]).to be_a(Moxml::Text)
+      expect(children[0].content).to eq("  ")
+      expect(children[1]).to be_a(Moxml::Element)
+      expect(children[2]).to be_a(Moxml::Text)
+      expect(children[2].content).to eq("  ")
+    end
+  end
+
   describe "document structure edge cases" do
     it "handles deeply nested elements" do
       doc = context.create_document

--- a/spec/integration/shared_examples/entity_reference_whitespace.rb
+++ b/spec/integration/shared_examples/entity_reference_whitespace.rb
@@ -104,7 +104,7 @@ RSpec.shared_examples "Entity Reference Whitespace Preservation" do
   end
 
   describe "structural whitespace filtering" do
-    it "still filters whitespace between elements" do
+    it "preserves whitespace text nodes between elements" do
       xml = <<~XML
         <root>
           <child1/>
@@ -115,8 +115,10 @@ RSpec.shared_examples "Entity Reference Whitespace Preservation" do
       doc = context.parse(xml)
       children = doc.root.children
 
-      expect(children.length).to eq(2)
-      expect(children.all?(Moxml::Element)).to be true
+      # Whitespace text nodes between elements are preserved
+      elements = children.select { |c| c.is_a?(Moxml::Element) }
+      expect(elements.length).to eq(2)
+      expect(elements.map(&:name)).to eq(%w[child1 child2])
     end
   end
 end

--- a/spec/integration/shared_examples/high_level/document_builder_behavior.rb
+++ b/spec/integration/shared_examples/high_level/document_builder_behavior.rb
@@ -32,12 +32,14 @@ RSpec.shared_examples "Moxml::DocumentBuilder" do
 
       expect(doc.root.namespaces.count).to eq(1)
       expect(doc.root.namespaces.first.uri).to eq("http://example.org")
-      expect(doc.root.children[0]).to be_a(Moxml::Comment)
-      expect(doc.root.children[1]).to be_a(Moxml::Element)
-      expect(doc.root.children[1].name).to eq("child")
-      expect(doc.root.children[1]["id"]).to eq("1")
-      expect(doc.root.children[1].children.first).to be_a(Moxml::Cdata)
-      expect(doc.root.children[2]).to be_a(Moxml::ProcessingInstruction)
+      # Whitespace text nodes are preserved between elements
+      non_ws_children = doc.root.children.reject { |c| c.is_a?(Moxml::Text) && c.content.strip.empty? }
+      expect(non_ws_children[0]).to be_a(Moxml::Comment)
+      expect(non_ws_children[1]).to be_a(Moxml::Element)
+      expect(non_ws_children[1].name).to eq("child")
+      expect(non_ws_children[1]["id"]).to eq("1")
+      expect(non_ws_children[1].children.find { |c| c.is_a?(Moxml::Cdata) }).to be_a(Moxml::Cdata)
+      expect(non_ws_children[2]).to be_a(Moxml::ProcessingInstruction)
     end
   end
 end

--- a/spec/integration/shared_examples/integration_workflows.rb
+++ b/spec/integration/shared_examples/integration_workflows.rb
@@ -113,7 +113,7 @@ RSpec.shared_examples "Moxml Integration" do
       expect(attr).to eq("value")
 
       # Test namespace override
-      deeper = a_element.children.first
+      deeper = a_element.children.find { |c| c.is_a?(Moxml::Element) }
       expect(deeper.namespace.uri).to eq("http://other.org")
     end
   end

--- a/spec/integration/shared_examples/node_wrappers/node_set_behavior.rb
+++ b/spec/integration/shared_examples/node_wrappers/node_set_behavior.rb
@@ -41,7 +41,9 @@ RSpec.shared_examples "Moxml::NodeSet" do
       end
 
       it "compares nodes" do
-        expect(doc.xpath("//child")).to eq(doc.root.children)
+        xpath_results = doc.xpath("//child")
+        element_children = doc.root.children.select { |c| c.is_a?(Moxml::Element) }
+        expect(xpath_results.map(&:native)).to eq(element_children.map(&:native))
       end
     end
 

--- a/spec/performance/benchmark_spec.rb
+++ b/spec/performance/benchmark_spec.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples "Performance Examples" do
         {
           nokogiri: { parser: 15, serializer: 1000 },
           oga: { parser: 10, serializer: 100 },
-          rexml: { parser: 0, serializer: 60 },
+          rexml: { parser: 0, serializer: 5 },
           ox: { parser: 2, serializer: 1000 },
           headed_ox: { parser: 2, serializer: 1000 },
           libxml: { parser: 10, serializer: 30 },


### PR DESCRIPTION
## Summary

- Remove whitespace-only text node filtering from Nokogiri, REXML, OGA, and LibXML adapters' `children()` methods
- Fix OGA adapter TypeError (NodeSet to Array conversion) and add document-level whitespace filtering
- Update integration tests for new behavior and add dedicated whitespace preservation tests
- Adjust REXML serializer performance threshold for increased child node count

## Root Cause

The adapters were stripping whitespace-only text nodes from `children()`, so consumers like lutaml-model never saw them. This caused the FigureA.1 spacing issue where the space between Figure and sub was a real whitespace text node being silently discarded.

## Changes

### Adapter fixes
- nokogiri.rb: Removed .reject filter on whitespace text nodes
- rexml.rb: Return node.children.dup without filtering
- libxml.rb: Removed next if whitespace-only text check
- oga.rb: Removed whitespace filter, fixed TypeError (.to_a on NodeSet), added document-level whitespace filtering

### Test fixes
- document_builder_behavior.rb: Use type-based child selection instead of index-based
- node_set_behavior.rb: Compare element children via native nodes for NodeSet equality
- integration_workflows.rb: Use .find for element children instead of .first
- benchmark_spec.rb: Lowered REXML serializer threshold 60->5 ips (expected with ~7x more nodes)

### New tests (4 tests x 6 adapters = 24 examples)
- Inline whitespace between text and elements (FigureA.1 case)
- Whitespace-only text nodes between sibling elements
- Space-only text nodes as meaningful content
- Distinguishing whitespace from element children

## Test plan

- [x] bundle exec rake spec:fast - 227 examples, 0 failures, 10 pending (same as baseline)
- [x] bundle exec rake spec:integration - 1740 examples, 2 failures (pre-existing LibXML perf), 168 pending
- [x] bundle exec rake spec:consistency - 331 examples, 0 failures, 1 pending