### PR TITLE
fix: restore :oga as the Opal default adapter

### DIFF
--- a/lib/moxml/adapter.rb
+++ b/lib/moxml/adapter.rb
@@ -11,9 +11,11 @@ module Moxml
     AVAILABLE_ADAPTERS = %i[nokogiri oga rexml ox headed_ox libxml].freeze
 
     # Adapters that work under the Opal (JavaScript) runtime.
-    # REXML is pure Ruby and Opal reimplements strscan/stringio in its stdlib,
-    # enabling REXML to compile cleanly to JavaScript.
-    OPAL_AVAILABLE_ADAPTERS = %i[rexml].freeze
+    # Oga is pure Ruby and designed with Opal compatibility in mind — it is the
+    # canonical XML parser for the JavaScript runtime. REXML is also pure Ruby
+    # but requires extensive runtime compat shims (regex features like /n,
+    # \u{...}, (?-mix:...) don't transpile cleanly), so it is opt-in only.
+    OPAL_AVAILABLE_ADAPTERS = %i[oga rexml].freeze
 
     # Registry mapping adapter names to their class name suffixes.
     # Special cases (like :headed_ox → "HeadedOx") live here instead of

--- a/lib/moxml/config.rb
+++ b/lib/moxml/config.rb
@@ -7,7 +7,7 @@ module Moxml
     VALID_LINE_ENDINGS = [LINE_ENDING_LF, LINE_ENDING_CRLF].freeze
     VALID_ADAPTERS = %i[nokogiri oga rexml ox headed_ox libxml].freeze
     DEFAULT_ADAPTER = :nokogiri
-    OPAL_DEFAULT_ADAPTER = :rexml
+    OPAL_DEFAULT_ADAPTER = :oga
 
     # Entity loading modes:
     # - :required - Must load entities, raise error if unavailable (default)

--- a/spec/moxml/adapter/platform_spec.rb
+++ b/spec/moxml/adapter/platform_spec.rb
@@ -2,73 +2,87 @@
 
 require "spec_helper"
 
-RSpec.describe Moxml::Adapter, ".platform_adapters" do
-  it "includes all known adapters under MRI" do
-    expect(described_class.platform_adapters).to include(:nokogiri, :oga,
-                                                         :rexml, :ox)
-  end
-
-  it "uses the AVAILABLE_ADAPTERS constant under MRI" do
-    expect(described_class.platform_adapters).to eq(Moxml::Adapter::AVAILABLE_ADAPTERS)
-  end
-end
-
-RSpec.describe Moxml::Adapter, ".available?" do
-  it "returns true for :oga" do
-    expect(described_class.available?(:oga)).to be true
-  end
-
-  it "returns true for :nokogiri under MRI" do
-    expect(described_class.available?(:nokogiri)).to be true
-  end
-
-  context "when Opal platform adapters are in effect" do
-    before do
-      allow(described_class).to receive(:platform_adapters)
-        .and_return(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS)
+RSpec.describe Moxml::Adapter do
+  describe ".platform_adapters" do
+    it "includes all known adapters under MRI" do
+      expect(described_class.platform_adapters).to include(:nokogiri, :oga,
+                                                           :rexml, :ox)
     end
 
-    it "returns false for :nokogiri" do
-      expect(described_class.available?(:nokogiri)).to be false
+    it "uses the AVAILABLE_ADAPTERS constant under MRI" do
+      expect(described_class.platform_adapters).to eq(Moxml::Adapter::AVAILABLE_ADAPTERS)
     end
+  end
 
+  describe ".available?" do
     it "returns true for :oga" do
       expect(described_class.available?(:oga)).to be true
     end
 
-    it "returns true for :rexml" do
-      expect(described_class.available?(:rexml)).to be true
-    end
-  end
-end
-
-RSpec.describe Moxml::Adapter, ".load" do
-  context "when Opal platform adapters are in effect" do
-    before do
-      allow(described_class).to receive(:platform_adapters)
-        .and_return(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS)
+    it "returns true for :nokogiri under MRI" do
+      expect(described_class.available?(:nokogiri)).to be true
     end
 
-    it "raises AdapterError for :nokogiri" do
-      expect { described_class.load(:nokogiri) }.to raise_error(
-        Moxml::AdapterError, /not available on this platform/
-      )
+    context "when Opal platform adapters are in effect" do
+      before do
+        allow(described_class).to receive(:platform_adapters)
+          .and_return(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS)
+      end
+
+      it "returns false for :nokogiri" do
+        expect(described_class.available?(:nokogiri)).to be false
+      end
+
+      it "returns true for :oga" do
+        expect(described_class.available?(:oga)).to be true
+      end
+
+      it "returns true for :rexml" do
+        expect(described_class.available?(:rexml)).to be true
+      end
     end
   end
-end
 
-RSpec.describe "Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS" do
-  it "lists :oga as the primary Opal adapter, with :rexml as opt-in" do
-    expect(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS).to eq(%i[oga rexml])
+  describe ".load" do
+    context "when Opal platform adapters are in effect" do
+      before do
+        allow(described_class).to receive(:platform_adapters)
+          .and_return(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS)
+      end
+
+      it "raises AdapterError for :nokogiri" do
+        expect { described_class.load(:nokogiri) }.to raise_error(
+          Moxml::AdapterError, /not available on this platform/
+        )
+      end
+    end
   end
-end
 
-RSpec.describe "Moxml::Adapter::CONST_NAME_MAP" do
-  it "maps :headed_ox to HeadedOx" do
-    expect(Moxml::Adapter::CONST_NAME_MAP[:headed_ox]).to eq("HeadedOx")
+  describe "OPAL_AVAILABLE_ADAPTERS" do
+    it "lists :oga as the primary Opal adapter, with :rexml as opt-in" do
+      expect(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS).to eq(%i[oga rexml])
+    end
   end
 
-  it "falls back to capitalize for unmapped adapters" do
-    expect(Moxml::Adapter::CONST_NAME_MAP[:nokogiri]).to be_nil
+  describe "CONST_NAME_MAP" do
+    it "maps :headed_ox to HeadedOx" do
+      expect(Moxml::Adapter::CONST_NAME_MAP[:headed_ox]).to eq("HeadedOx")
+    end
+
+    it "falls back to capitalize for unmapped adapters" do
+      expect(Moxml::Adapter::CONST_NAME_MAP[:nokogiri]).to be_nil
+    end
+  end
+
+  describe "default adapter / available list invariants" do
+    it "DEFAULT_ADAPTER is a member of AVAILABLE_ADAPTERS" do
+      expect(Moxml::Adapter::AVAILABLE_ADAPTERS)
+        .to include(Moxml::Config::DEFAULT_ADAPTER)
+    end
+
+    it "OPAL_DEFAULT_ADAPTER is a member of OPAL_AVAILABLE_ADAPTERS" do
+      expect(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS)
+        .to include(Moxml::Config::OPAL_DEFAULT_ADAPTER)
+    end
   end
 end

--- a/spec/moxml/adapter/platform_spec.rb
+++ b/spec/moxml/adapter/platform_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Moxml::Adapter, ".available?" do
       expect(described_class.available?(:nokogiri)).to be false
     end
 
+    it "returns true for :oga" do
+      expect(described_class.available?(:oga)).to be true
+    end
+
     it "returns true for :rexml" do
       expect(described_class.available?(:rexml)).to be true
     end
@@ -54,8 +58,8 @@ RSpec.describe Moxml::Adapter, ".load" do
 end
 
 RSpec.describe "Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS" do
-  it "contains only :rexml" do
-    expect(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS).to eq(%i[rexml])
+  it "lists :oga as the primary Opal adapter, with :rexml as opt-in" do
+    expect(Moxml::Adapter::OPAL_AVAILABLE_ADAPTERS).to eq(%i[oga rexml])
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,7 +101,7 @@ RSpec.configure do |config|
 end
 
 Moxml.configure do |config|
-  config.adapter = RUBY_ENGINE == "opal" ? :rexml : :nokogiri
+  config.adapter = RUBY_ENGINE == "opal" ? :oga : :nokogiri
   config.strict_parsing = true
   config.default_encoding = "UTF-8"
   config.entity_load_mode = :optional if RUBY_ENGINE == "opal"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,7 +101,7 @@ RSpec.configure do |config|
 end
 
 Moxml.configure do |config|
-  config.adapter = RUBY_ENGINE == "opal" ? :oga : :nokogiri
+  config.adapter = RUBY_ENGINE == "opal" ? Moxml::Config::OPAL_DEFAULT_ADAPTER : Moxml::Config::DEFAULT_ADAPTER
   config.strict_parsing = true
   config.default_encoding = "UTF-8"
   config.entity_load_mode = :optional if RUBY_ENGINE == "opal"


### PR DESCRIPTION
## Summary

Closes #89.

Restores `:oga` as the Opal default adapter, reverting the `:rexml` default that was introduced in `d7dcebc`. REXML remains available as an explicit opt-in via `Moxml.new(:rexml)` under Opal — only the zero-config default changes.

### Why

PR #71 originally chose `:oga` for the Opal default. That choice was correct: Oga is the canonical pure-Ruby XML parser designed with Opal compatibility in mind. It is what Plurimath loads under Opal (`plurimath/setup/oga.rb`) and what `plurimath-js` already vendors and pre-compiles.

Commit `d7dcebc` reverted to `:rexml` and shipped a pile of REXML-on-Opal compat shims (`rexml/source.rb`, `rexml/text.rb`, `rexml/namespace.rb`, `rexml/parsers/baseparser.rb`, plus `String#chomp!`, `StringIO`, and `Encoding` runtime overrides). Those shims are reactive patches for an unsustainable direction — every new REXML release risks introducing another regex or string API that doesn't transpile to JavaScript.

Concrete failures seen downstream in `plurimath-js`:

- `rexml/source.rb` — `/n` NoEncoding regex flag incompatible with JS regex engine
- `rexml/namespace.rb` — `\u{10000}` Unicode codepoint escapes don't transpile
- `rexml/text.rb` — `VALID_XML_CHARS` regex needs to be BMP-only
- `rexml/parsers/baseparser.rb` — POSIX classes, `\A`, atomic groups

Each surfaces at runtime as `SyntaxError: Invalid regular expression` in the JS bundle, blocking the entire Opal build.

### What changes

- `lib/moxml/config.rb` — `OPAL_DEFAULT_ADAPTER` reverted from `:rexml` to `:oga`
- `lib/moxml/adapter.rb` — `OPAL_AVAILABLE_ADAPTERS` now `[:oga, :rexml]`; REXML stays as opt-in
- `spec/spec_helper.rb` — Opal spec helper uses `:oga` to mirror the new default
- `spec/moxml/adapter/platform_spec.rb` — covers `:oga` availability under Opal

The existing REXML-on-Opal compat overrides and the `opal_smoke_spec.rb` (which tests `Moxml.new(:rexml)` under Opal) are intentionally left in place — the opt-in path still needs to work.

## Test plan

- [x] `bundle exec rspec` — 3784 examples, 0 failures, 194 pre-existing Ox pending
- [x] `bundle exec rspec spec/moxml/adapter/platform_spec.rb` — platform assertions pass for `[:oga, :rexml]`
- [ ] Opal CI workflow (`.github/workflows/opal.yml`) — exercises `Moxml.new(:oga)` path under opal-rspec; will run on PR
- [ ] Downstream: `plurimath-js` full build with moxml pinned to this branch (separate follow-up)
