### PR TITLE
ci(release): default workflow_dispatch to one-step publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ on:
           Next release version. Possible values: x.y.z, major, minor, patch or pre|rc|etc
         required: true
         default: 'skip'
+      gated:
+        description: |
+          Defer rubygems publish to a separate repository_dispatch (do-release) run.
+          - false (default): bump + tag + publish in one step.
+          - true: bump + tag only; publish when do-release is triggered.
+        required: false
+        default: false
+        type: boolean
   repository_dispatch:
     types: [ do-release ]
 
@@ -21,6 +29,7 @@ jobs:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
+      gated: ${{ inputs.gated == true }}
     secrets:
       rubygems-api-key: ${{ secrets.LUTAML_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `gated` boolean input to `release.yml` workflow_dispatch (default `false`).
- Passes `gated` through to `metanorma/ci/rubygems-release.yml`, which already supports it (default `true` upstream).
- One manual trigger now bumps + tags + publishes; selecting `gated: true` keeps the conservative two-step path.

## Why
Previously every `workflow_dispatch` only bumped and tagged because `gated` defaulted to `true` upstream and was never overridden here, forcing a second `repository_dispatch` (`do-release`) to actually publish. Two-step is a fine option but a poor default when the trigger is already a deliberate human action.

## Behavior matrix
| Event | `gated` input | Result |
|---|---|---|
| `workflow_dispatch` | `false` (new default) | bump + tag + **publish** |
| `workflow_dispatch` | `true` | bump + tag only (publish via `do-release`) |
| `repository_dispatch` (do-release) | n/a | publish (upstream short-circuits on event_name) |

## Test plan
- [ ] CI passes on this PR
- [ ] On next patch: trigger `workflow_dispatch` with `next_version=patch`, default `gated=false`, and confirm rubygems.org receives the new version without a separate `do-release` dispatch
- [ ] Confirm `repository_dispatch` (do-release) path still works as fallback